### PR TITLE
Add naive implementation of Pay flow.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,7 +387,7 @@ checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 [[package]]
 name = "libzkchannels-crypto"
 version = "0.1.0"
-source = "git+ssh://git@github.com/boltlabs-inc/libzkchannels-crypto.git?branch=primitives-api#6aba0082ddafed2844fc8ee8745c87261f6c3826"
+source = "git+ssh://git@github.com/boltlabs-inc/libzkchannels-crypto.git?branch=primitives-api-placeholder#6eae60e817dc4da74c0f002974945fa5f1b47e69"
 dependencies = [
  "bls12_381",
  "ff",
@@ -399,7 +399,7 @@ dependencies = [
 [[package]]
 name = "libzkchannels-toolkit"
 version = "0.1.0"
-source = "git+ssh://git@github.com/boltlabs-inc/libzkchannels-crypto.git?branch=primitives-api#6aba0082ddafed2844fc8ee8745c87261f6c3826"
+source = "git+ssh://git@github.com/boltlabs-inc/libzkchannels-crypto.git?branch=primitives-api-placeholder#6eae60e817dc4da74c0f002974945fa5f1b47e69"
 dependencies = [
  "bls12_381",
  "libzkchannels-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ path = "src/bin/merchant/main.rs"
 allow_explicit_certificate_trust = []
 
 [dependencies]
-libzkchannels-toolkit = { git = "ssh://git@github.com/boltlabs-inc/libzkchannels-crypto.git", branch = "primitives-api" }
+# libzkchannels-toolkit = { git = "ssh://git@github.com/boltlabs-inc/libzkchannels-crypto.git", branch = "primitives-api-placeholder" }
+libzkchannels-toolkit = { git = "ssh://git@github.com/boltlabs-inc/libzkchannels-crypto.git", branch = "primitives-api-placeholder" }
 tokio = { version = "1", features = ["full"] }
 tokio-rustls = "0.22"
 anyhow = "1"

--- a/src/bin/customer/main.rs
+++ b/src/bin/customer/main.rs
@@ -2,9 +2,19 @@ use std::{env, path::Path};
 use tokio_rustls::webpki::DNSNameRef;
 
 use dialectic::prelude::*;
-
+use libzkchannels_toolkit::{
+    nonce::Nonce,
+    parameters::CustomerParameters,
+    proofs::PayProof,
+    revlock::{
+        RevocationLock, RevocationLockBlindingFactor, RevocationLockCommitment, RevocationSecret,
+    },
+    states::{
+        ChannelId, CloseStateCommitment, CustomerBalance, MerchantBalance, State, StateCommitment,
+    },
+};
 use zeekoe::{
-    protocol::Ping,
+    protocol::pay::Customer,
     transport::{connect, read_single_certificate, ClientConfig, TlsClientChan},
 };
 
@@ -31,13 +41,68 @@ async fn main() -> Result<(), anyhow::Error> {
     };
 
     // Connect to server
-    let chan: TlsClientChan<<Ping as Session>::Dual> = connect(config).await?;
+    let chan: TlsClientChan<Customer> = connect(config).await?;
 
-    // Enact the client `Ping` protocol
-    let chan = chan.send("ping".to_string()).await?;
-    let (response, chan) = chan.recv().await?;
-    chan.close();
-    println!("{}", response);
+    // Assemble the information we need to send the server.
+    //
+    // let mut rng = rand::thread_rng();
+    // let merchant_balance = MerchantBalance;
+    // let customer_balance = CustomerBalance;
+    // let customer_parameters = CustomerParameters {
+    //     merchant_signing_pk: PublicKey {
+    //         g1: G1Affine::identity(),
+    //         y1s: vec![],
+    //         g2: G2Affine::identity(),
+    //         x2: G2Affine::identity(),
+    //         y2s: vec![],
+    //     },
+    //     commitment_params: todo!(),
+    // };
+    // let prev_state = State::new(&mut rng, ChannelId, merchant_balance,
+    // customer_balance); let (close_state_commitment,
+    // close_state_blinding_factor) = state.close_state().commit(&mut rng,
+    // &customer_parameters); let nonce: Nonce = *prev_state.nonce();
 
+    // construct PayProof
+    // PayProof::new(
+    //     &rng,
+    //     customer_parameters,
+    //     &state,
+    // );
+
+    // Enact the client `Customer` protocol
+    let chan = chan.send(Nonce).await?;
+    let chan = chan.send(PayProof).await?;
+    let chan = chan.send(RevocationLockCommitment()).await?;
+    let chan = chan.send(CloseStateCommitment()).await?;
+    let chan = chan.send(StateCommitment()).await?;
+
+    offer!(in chan {
+        0 => {
+            println!("Merchant aborted before CustomerRevokePreviousPayToken");
+            chan.close();
+        },
+
+        1 => {
+            let (_close_state_blinding_signature, chan) = chan.recv().await?;
+            let chan = chan.choose::<1>().await?;
+            let chan = chan.send(RevocationLock).await?;
+            let chan = chan.send(RevocationSecret).await?;
+            let chan = chan.send(RevocationLockBlindingFactor()).await?;
+
+            offer!(in chan {
+                0 => {
+                    println!("Merchant aborted before MerchantIssueNewPayToken");
+                    chan.close();
+                },
+
+                1 => {
+                    let (_blinded_pay_token, chan) = chan.recv().await?;
+                    println!("Customer completed Pay flow successfully");
+                    chan.close();
+                },
+            })?;
+        },
+    })?;
     Ok(())
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -22,13 +22,12 @@ type ChooseAbort<Next> = Session! {
 
 // All protocols are from the perspective of the customer.
 
-pub use pay::Pay;
-
 pub mod pay {
     use super::*;
 
     /// The full "pay" protocol's session type.
-    pub type Pay = CustomerStartPayment;
+    pub type Customer = CustomerStartPayment;
+    pub type Merchant = <Customer as Session>::Dual;
 
     pub type CustomerStartPayment = Session! {
         send Nonce;
@@ -47,7 +46,7 @@ pub mod pay {
     pub type CustomerRevokePreviousPayToken = Session! {
         send RevocationLock;
         send RevocationSecret;
-        send RevocationLockCommitmentRandomness;
+        send RevocationLockBlindingFactor;
         OfferAbort<MerchantIssueNewPayToken>;
     };
 


### PR DESCRIPTION
This implements a 'placeholder' Pay session which simply generates the exact parameters for each step, resulting in a 'successful payment' (neither side ever aborts).

To actually give it a spin, use the instructions here: https://github.com/boltlabs-inc/zeekoe/blob/dev-docs-and-generate-cert-script/README.md

Closes #10 