### PR TITLE
Add edition = 2018 to rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,3 @@
+edition = "2018"
 unstable_features = true
-
 wrap_comments = true


### PR DESCRIPTION
On my setup-- which is rust.vim in neovim-- it runs `rustfmt` on save, which errors because it reads `rustfmt.toml` and defaults to `edition = '2015'`.