### PR TITLE
Merchant unilateral close

### DIFF
--- a/src/bin/customer/close.rs
+++ b/src/bin/customer/close.rs
@@ -98,6 +98,13 @@ async fn finalize_close(config: self::Config) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// React to an on-chain merchant dispute.
+async fn process_dispute() -> Result<(), anyhow::Error> {
+    // Update the database to indicate loss of funds.
+    // This should only be updated after the merchant dispute is confirmed at the correct depth.
+    todo!()
+}
+
 async fn mutual_close(
     close: &Close,
     rng: StdRng,

--- a/src/bin/customer/close.rs
+++ b/src/bin/customer/close.rs
@@ -77,7 +77,8 @@ async fn close(close: &Close, rng: StdRng, config: self::Config) -> Result<(), a
 /// confirmation depth.
 #[allow(unused)]
 async fn claim_funds(close: &Close, config: self::Config) -> Result<(), anyhow::Error> {
-    // TODO: assert that the db status is PENDING_CLOSE
+    // TODO: assert that the db status is PENDING_CLOSE,
+    // Update final balances to indicate that the merchant balance has been paid out to the merchant.
 
     // TODO: Call the customer claim entrypoint which will take:
     // - contract ID
@@ -97,8 +98,11 @@ async fn claim_funds(close: &Close, config: self::Config) -> Result<(), anyhow::
 #[allow(unused)]
 async fn finalize_close(config: self::Config) -> Result<(), anyhow::Error> {
     // TODO: update status in db from PENDING to CLOSED with the final balances.
-    // - for custClaim, this will match the PENDING_CLOSE balances
-    // - for dispute or merchClaim, this will send all money to the merchant.
+    // - for custClaim, this will match the PENDING_CLOSE balances (the merchant balance was
+    //   already paid out; here, only the customer final balance needs to be updated)
+    // - for dispute, indicate that the customer balance is paid out to the merchant (the
+    //   merchant balance was already paid out)
+    // - for merchClaim, indicate that all balances are paid out to the merchant.
 
     Ok(())
 }

--- a/src/bin/customer/close.rs
+++ b/src/bin/customer/close.rs
@@ -99,13 +99,6 @@ async fn finalize_close(config: self::Config) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// React to an on-chain merchant dispute.
-async fn process_dispute() -> Result<(), anyhow::Error> {
-    // Update the database to indicate loss of funds.
-    // This should only be updated after the merchant dispute is confirmed at the correct depth.
-    todo!()
-}
-
 async fn mutual_close(
     close: &Close,
     rng: StdRng,

--- a/src/bin/customer/close.rs
+++ b/src/bin/customer/close.rs
@@ -88,13 +88,17 @@ async fn claim_funds(close: &Close, config: self::Config) -> Result<(), anyhow::
 /// Update channel state once close operations are finalized.
 ///
 /// **Usage**: this function is called as response to an on-chain event, either:
-/// - a claim operation is confirmed on chain at an appropriate depth.
+/// - a custClaim operation is confirmed on chain at an appropriate depth.
+/// - a merchClaim operation is confirmed on chain at an appropriate depth
 /// - a dispute operation is confirmed on chain at an appropriate depth.
+///
+/// Note: these functions are separate in the merchant implementation. Maybe they should also be
+/// separate here.
 #[allow(unused)]
 async fn finalize_close(config: self::Config) -> Result<(), anyhow::Error> {
     // TODO: update status in db from PENDING to CLOSED with the final balances.
-    // - for claim, this will match the PENDING_CLOSE balances
-    // - for dispute, this will show loss of funds - all money to the merchant.
+    // - for custClaim, this will match the PENDING_CLOSE balances
+    // - for dispute or merchClaim, this will send all money to the merchant.
 
     Ok(())
 }
@@ -175,7 +179,7 @@ async fn mutual_close(
 /// that the mutual close operation has been applied and has reached required confirmation depth.
 /// It will only be called after a successful execution of [`mutual_close()`].
 #[allow(unused)]
-async fn process_mutual_close_confirmation(
+async fn finalize_mutual_close(
     rng: &mut StdRng,
     config: self::Config,
     label: ChannelName,

--- a/src/bin/customer/close.rs
+++ b/src/bin/customer/close.rs
@@ -75,6 +75,7 @@ async fn close(close: &Close, rng: StdRng, config: self::Config) -> Result<(), a
 ///
 /// **Usage**: this function is called in response to an on-chain event. It is called after the
 /// custClose operation is confirmed on chain at an appropriate depth.
+#[allow(unused)]
 async fn process_confirmed_customer_close() {
     // TODO: assert that the db status is PENDING_CLOSE,
     // Indicate that the merchant balance has been paid out to the merchant.

--- a/src/bin/customer/close.rs
+++ b/src/bin/customer/close.rs
@@ -72,8 +72,9 @@ async fn close(close: &Close, rng: StdRng, config: self::Config) -> Result<(), a
 
 /// Claim final balance of the channel.
 ///
-/// **Usage**: this function is called as a response to an on-chain event. It is called
-/// after the contract claim delay has passed.
+/// **Usage**: this function is called as a response to an on-chain event. It is only called after
+/// the contract claim delay has passed and the claim entrypoint is confirmed at the required
+/// confirmation depth.
 #[allow(unused)]
 async fn claim_funds(close: &Close, config: self::Config) -> Result<(), anyhow::Error> {
     // TODO: assert that the db status is PENDING_CLOSE

--- a/src/bin/merchant/close.rs
+++ b/src/bin/merchant/close.rs
@@ -72,18 +72,17 @@ async fn process_customer_close() -> Result<(), anyhow::Error> {
     // TODO: Extract revocation lock from notification and atomically
     // - check that it is fresh (e.g. not in the database with a revocation secret),
     // - insert it into the database,
-    // - return whatever else is already associated with the lock.
+    // - retrieve any secrets already associated with the lock.
 
-    // TODO: If the lock already has an associated revocation secret, update channel status to DISPUTE,
-    // filling in the "final balances" in the database.
+    // TODO: if the lock *does not* have a revocation secret, update channel status to PENDING_CLOSE.
+
+    // TODO: If the lock already has an associated revocation secret, update channel status to DISPUTE.
 
     // TODO: If the lock already has an associated revocation secret, call the merchant dispute
     // entrypoint with:
     // - contract id
     // - revocation secret
     // E.g. call the "dispute" function from escrow API.
-
-    // TODO: update channel status to PENDING_CLOSE.
 
     todo!()
 }
@@ -94,8 +93,11 @@ async fn process_customer_close() -> Result<(), anyhow::Error> {
 /// was posted on chain *and* is confirmed at the required confirmation depth.
 #[allow(unused)]
 async fn finalize_customer_close() -> Result<(), anyhow::Error> {
-    // TODO: assert that status is PENDING
-    // TODO: update database channel status to CLOSED and set final balances.
+    // TODO: if database status is PENDING_CLOSE, update database channel status to CLOSED and set
+    // final balances.
+
+    // TODO: if database status is DISPUTE, update merchant final balance to include the merchant
+    // balance. (process_customer_close should have already set the other dispute actions in motion).
 
     todo!()
 }
@@ -237,7 +239,7 @@ async fn expiry(
 /// is confirmed on chain to an appropriate depth _and_ the timelock period has passed without
 /// any other operation being posted to the contract.
 #[allow(unused)]
-async fn claim() {
+async fn claim_funds() {
     // TODO: Assert database status is PENDING_CLOSE
 
     // TODO: call merchClaim entrypoint, which will take
@@ -249,10 +251,11 @@ async fn claim() {
 
 /// Finalize the channel balances for a merchant-closed channel.
 ///
-/// **Usage**: this is called after the claim operation is confirmed on chain to an appropriate
+/// **Usage**: this is called after the merchClaim operation is confirmed on chain to an appropriate
 /// depth.
 #[allow(unused)]
 async fn finalize_close() -> Result<(), anyhow::Error> {
+    // TODO: assert database status is PENDING_CLOSE.
     // TODO: update database status to CLOSED with the correct balances.
     Ok(())
 }

--- a/src/bin/merchant/close.rs
+++ b/src/bin/merchant/close.rs
@@ -3,9 +3,16 @@
 //* TODO: handle merchant expiry closes.
 use {anyhow::Context, async_trait::async_trait, rand::rngs::StdRng};
 
+use std::sync::Arc;
+
+use super::Command;
+use rand::SeedableRng;
+
+use sqlx::SqlitePool;
 use zeekoe::{
     abort,
-    merchant::{config::Service, database::QueryMerchant, server::SessionKey, Chan},
+    customer::config::DatabaseLocation,
+    merchant::{cli, config::Service, database::QueryMerchant, server::SessionKey, Chan, Config},
     offer_abort, proceed,
     protocol::{self, close, ChannelStatus, Party::Merchant},
 };
@@ -173,5 +180,31 @@ async fn zkabacus_close(
         }
         // Abort if the close signature was invalid.
         Verification::Failed => abort!(in chan return close::Error::InvalidCloseStateSignature),
+    }
+}
+
+#[async_trait]
+impl Command for cli::Close {
+    async fn run(self, config: Config) -> Result<(), anyhow::Error> {
+        // Retrieve zkAbacus config from the database
+        // TODO: this is copied from main.rs, should it be a nicer function somewhere?
+        let database: Arc<dyn QueryMerchant> = match config.database {
+            DatabaseLocation::InMemory => Arc::new(SqlitePool::connect("file::memory:").await?),
+            DatabaseLocation::Sqlite(ref uri) => Arc::new(SqlitePool::connect(uri).await?),
+            DatabaseLocation::Postgres(_) => {
+                return Err(anyhow::anyhow!(
+                    "Postgres database support is not yet implemented"
+                ))
+            }
+        };
+
+        // Either initialize the merchant's config afresh, or get existing config if it exists (it should already exist)
+        let _merchant_config = database
+            .fetch_or_create_config(&mut StdRng::from_entropy()) // TODO: allow determinism
+            .await?;
+
+        // Next steps: parse self options, run close.
+
+        todo!()
     }
 }

--- a/src/bin/merchant/close.rs
+++ b/src/bin/merchant/close.rs
@@ -6,7 +6,6 @@ use {anyhow::Context, async_trait::async_trait, rand::rngs::StdRng};
 use super::{database, Command};
 use rand::SeedableRng;
 
-use tokio_rustls::rustls::sign::any_supported_type;
 use zeekoe::{
     abort,
     merchant::{cli, config::Service, database::QueryMerchant, server::SessionKey, Chan, Config},

--- a/src/bin/merchant/close.rs
+++ b/src/bin/merchant/close.rs
@@ -66,7 +66,7 @@ impl Method for Close {
 /// Process a customer close event.
 ///
 /// **Usage**: this should be called after receiving a notification that a customer close entrypoint
-/// was posted on chain. Should not wait for the transaction to be confirmed at the required confirmation depth.
+/// was confirmed on chain at any depth.
 #[allow(unused)]
 async fn process_customer_close() -> Result<(), anyhow::Error> {
     // TODO: Extract revocation lock from notification and atomically
@@ -90,14 +90,14 @@ async fn process_customer_close() -> Result<(), anyhow::Error> {
 /// Process a confirmed customer close event.
 ///
 /// **Usage**: this should be called after receiving a notification that a customer close entrypoint
-/// was posted on chain *and* is confirmed at the required confirmation depth.
+/// is confirmed on chain *at the required confirmation depth*.
 #[allow(unused)]
 async fn finalize_customer_close() -> Result<(), anyhow::Error> {
     // TODO: if database status is PENDING_CLOSE, update database channel status to CLOSED and set
     // final balances.
 
     // TODO: if database status is DISPUTE, update merchant final balance to include the merchant
-    // balance. (process_customer_close should have already set the other dispute actions in motion).
+    // balance.
 
     todo!()
 }
@@ -236,7 +236,7 @@ async fn expiry(
 /// Claim the channel balances.
 ///
 /// **Usage**: this is called in response to an on-chain event: when the expiry operation
-/// is confirmed on chain to an appropriate depth _and_ the timelock period has passed without
+/// is confirmed on chain _and_ the timelock period has passed without
 /// any other operation being posted to the contract.
 #[allow(unused)]
 async fn claim_funds() {
@@ -249,13 +249,15 @@ async fn claim_funds() {
     // This function will transfer all the channel funds to the merchant account.
 }
 
-/// Finalize the channel balances for a merchant-closed channel.
+/// Finalize the channel balances. This is called during a unilateral merchant close flow (in the
+/// case that the customer does not post updated balances).
 ///
 /// **Usage**: this is called after the merchClaim operation is confirmed on chain to an appropriate
 /// depth.
 #[allow(unused)]
 async fn finalize_close() -> Result<(), anyhow::Error> {
     // TODO: assert database status is PENDING_CLOSE.
-    // TODO: update database status to CLOSED with the correct balances.
+    // TODO: update database status to CLOSED. Indicate that all balances are paid out
+    // to the merchant.
     Ok(())
 }

--- a/src/bin/merchant/close.rs
+++ b/src/bin/merchant/close.rs
@@ -71,10 +71,8 @@ async fn process_customer_close() -> Result<(), anyhow::Error> {
     // - insert it into the database,
     // - return whatever else is already associated with the lock.
 
-    // TODO: Extract channel balances and fill in "final balance" columns in database.
-    // Note: this might be done atomically with the following status updates.
-
-    // TODO: If the lock already has an associated revocation secret, update channel status to DISPUTE
+    // TODO: If the lock already has an associated revocation secret, update channel status to DISPUTE,
+    // filling in the "final balances" in the database.
 
     // TODO: If the lock already has an associated revocation secret, call the merchant dispute
     // entrypoint with:

--- a/src/bin/merchant/main.rs
+++ b/src/bin/merchant/main.rs
@@ -219,6 +219,7 @@ pub async fn main_with_cli(cli: Cli) -> Result<(), anyhow::Error> {
         List(list) => list.run(config.await?).await,
         Show(show) => show.run(config.await?).await,
         Run(run) => run.run(config.await?).await,
+        Close(close) => close.run(config.await?).await,
     }
 }
 

--- a/src/cli/merchant.rs
+++ b/src/cli/merchant.rs
@@ -1,5 +1,7 @@
 use {std::path::PathBuf, structopt::StructOpt};
 
+use zkabacus_crypto::ChannelId;
+
 pub use crate::merchant;
 
 #[derive(Debug, StructOpt)]
@@ -45,7 +47,6 @@ pub struct Close {
     #[structopt(long)]
     pub all: bool,
 
-    /// TODO: replace this with a ChannelId or a ChannelIdPrefix of some flavor.
     #[structopt(long)]
-    pub channel: bool,
+    pub channel: Option<ChannelId>,
 }

--- a/src/cli/merchant.rs
+++ b/src/cli/merchant.rs
@@ -17,6 +17,7 @@ pub enum Merchant {
     Show(Show),
     Configure(Configure),
     Run(Run),
+    Close(Close),
 }
 
 #[derive(Debug, StructOpt)]
@@ -37,3 +38,14 @@ pub struct Configure {}
 #[derive(Debug, StructOpt)]
 #[non_exhaustive]
 pub struct Run {}
+
+#[derive(Debug, StructOpt)]
+#[non_exhaustive]
+pub struct Close {
+    #[structopt(long)]
+    pub all: bool,
+
+    /// TODO: replace this with a ChannelId or a ChannelIdPrefix of some flavor.
+    #[structopt(long)]
+    pub channel: bool,
+}


### PR DESCRIPTION
This adds an outline of merchant's unilateral close, including the CLI to initiate it and indications of how the db and escrow agent should be called.

It is dependent on #110 and #124, and as such will probably get rebased a bunch until those branches are stable and merged. 
It includes the merchant close functionality from #113. **Update**: now stable.

A couple notes:
- what's the status of specifying channel ids by prefixes? Currently the command line argument expects a ChannelId; what will happen if it only gets a prefix? Do the sqlite encode/decode functions in libzkchannels take care of this? @yaymukund 
- related: I have not tested the CLI because I haven't been able to establish a channel locally. I think @kwf knows about this situation; it might be worthwhile to delegate fixing this to someone and/or share the setup required.
- We have discussed "outputting" the final balances of the channel, but I don't think there's currently a space to store them in the database. I've noted places where we would need to save them. See boltlabs-inc/zkchannels-spec#51
