### PR TITLE
Store the merchant & customer deposits to the db during (both) establish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2503,7 +2503,7 @@ dependencies = [
 [[package]]
 name = "zkabacus-crypto"
 version = "0.1.0"
-source = "git+ssh://git@github.com/boltlabs-inc/libzkchannels-crypto.git?branch=main#3dd54c4733f6bd9de3810088788cd464dcfd4c4d"
+source = "git+ssh://git@github.com/boltlabs-inc/libzkchannels-crypto.git?branch=main#2f847b9af1aeaf79fd1fb3955af5a604e49b279e"
 dependencies = [
  "base64",
  "bincode",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "zkchannels-crypto"
 version = "0.1.0"
-source = "git+ssh://git@github.com/boltlabs-inc/libzkchannels-crypto.git?branch=main#3dd54c4733f6bd9de3810088788cd464dcfd4c4d"
+source = "git+ssh://git@github.com/boltlabs-inc/libzkchannels-crypto.git?branch=main#2f847b9af1aeaf79fd1fb3955af5a604e49b279e"
 dependencies = [
  "arrayvec 0.7.1",
  "bincode",

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -68,6 +68,16 @@
       ]
     }
   },
+  "4ed55f3cbe97f7dcb73ef0c18ebe3baa6213eae42e8604eb6371142cc56fcb83": {
+    "query": "INSERT INTO merchant_channels (\n                channel_id,\n                contract_id,\n                merchant_deposit,\n                customer_deposit,\n                status\n            ) VALUES (?, ?, ?, ?, ?)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 5
+      },
+      "nullable": []
+    }
+  },
   "69377cabe38e67da48503697a4f862521c02db27307026e082bfcc042a57f092": {
     "query": "SELECT state AS \"state: State\" FROM customer_channels WHERE label = ?",
     "describe": {
@@ -106,16 +116,6 @@
       "nullable": []
     }
   },
-  "a7790da586c93d20f5f26d7d927283566efdfe5ee684f4c0fe5d029da0cc6656": {
-    "query": "INSERT INTO customer_channels (label, address, state) VALUES (?, ?, ?)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 3
-      },
-      "nullable": []
-    }
-  },
   "aa91a624c3efb7bbda7d2501c6b93f13513b36b9ebbb3410275cb3bd9bb1965e": {
     "query": "\n            INSERT INTO\n                merchant_config\n            (signing_keypair, revocation_commitment_parameters, range_proof_parameters)\n                VALUES\n            (?, ?, ?)\n            ",
     "describe": {
@@ -144,12 +144,12 @@
       ]
     }
   },
-  "de50503397e87da087b33c6b1ba45a26c2765bff0dd0a9c6cc52a1cd15c0e0ea": {
-    "query": "INSERT INTO merchant_channels (channel_id, contract_id, status) VALUES (?, ?, ?)",
+  "da49f0dabf981510d17157dafc884c64e2cded2242a8f1465a4b109ff0194599": {
+    "query": "INSERT INTO customer_channels (\n                    label,\n                    address,\n                    merchant_deposit,\n                    customer_deposit,\n                    state\n                ) VALUES (?, ?, ?, ?, ?)",
     "describe": {
       "columns": [],
       "parameters": {
-        "Right": 3
+        "Right": 5
       },
       "nullable": []
     }

--- a/src/bin/merchant/establish.rs
+++ b/src/bin/merchant/establish.rs
@@ -185,7 +185,12 @@ async fn approve_and_establish(
 
     // Store the channel information in the database
     database
-        .new_channel(&channel_id, &contract_id)
+        .new_channel(
+            &channel_id,
+            &contract_id,
+            &merchant_deposit,
+            &customer_deposit,
+        )
         .await
         .context("Failed to insert new channel_id, contract_id in database")?;
 

--- a/src/database/customer.rs
+++ b/src/database/customer.rs
@@ -128,6 +128,8 @@ impl QueryCustomer for SqlitePool {
         address: &ZkChannelAddress,
         inactive: Inactive,
     ) -> std::result::Result<(), (Inactive, Error)> {
+        let merchant_deposit = *inactive.merchant_balance();
+        let customer_deposit = *inactive.customer_balance();
         let state = State::Inactive(inactive);
         (|| async {
             let mut transaction = self.begin().await?;
@@ -150,9 +152,17 @@ impl QueryCustomer for SqlitePool {
             }
 
             let result = sqlx::query!(
-                "INSERT INTO customer_channels (label, address, state) VALUES (?, ?, ?)",
+                "INSERT INTO customer_channels (
+                    label,
+                    address,
+                    merchant_deposit,
+                    customer_deposit,
+                    state
+                ) VALUES (?, ?, ?, ?, ?)",
                 label,
                 address,
+                merchant_deposit,
+                customer_deposit,
                 state,
             )
             .execute(&mut transaction)

--- a/src/database/migrations/customer/202106221018_setup.sql
+++ b/src/database/migrations/customer/202106221018_setup.sql
@@ -2,6 +2,8 @@ CREATE TABLE customer_channels (
   id SERIAL PRIMARY KEY,
   label TEXT NOT NULL UNIQUE,
   address BLOB NOT NULL,
+  merchant_deposit BLOB NOT NULL,
+  customer_deposit BLOB NOT NULL,
   state BLOB NOT NULL
 );
 CREATE UNIQUE INDEX customer_channels_label on customer_channels (label);

--- a/src/database/migrations/merchant/202106211725_setup.sql
+++ b/src/database/migrations/merchant/202106211725_setup.sql
@@ -22,6 +22,8 @@ CREATE TABLE merchant_channels (
   id SERIAL PRIMARY KEY,
   channel_id BLOB NOT NULL,
   contract_id BLOB NOT NULL,
+  merchant_deposit BLOB NOT NULL,
+  customer_deposit BLOB NOT NULL,
   status TEXT NOT NULL
     CHECK (status IN (
       "originated",


### PR DESCRIPTION
We need this information if either the merchant or customer wish to inspect the state of open channels.

Blocked on https://github.com/boltlabs-inc/libzkchannels-crypto/pull/130