### PR TITLE
Modify instructions to use `git-fetch-with-cli`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To build the project, you will need a recent version of stable Rust. This projec
 Rust version 1.52.1.
 
 ```bash
-cargo build --features "allow_explicit_certificate_trust"
+CARGO_NET_GIT_FETCH_WITH_CLI=true cargo build --features "allow_explicit_certificate_trust"
 ```
 
 Notice also that we specify the build option `allow_explicit_certificate_trust`. Without this


### PR DESCRIPTION
This addresses the build error from the Tezos feedback:

>     When following the instructions and executing “cargo build --features "allow_explicit_certificate_trust", I get the following error

Long term, this should not be necessary since libzkchannels-crypto will
be public.