### PR TITLE
Remove the wrap_comments flag. This doesn't work on stable Rust.

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,2 @@
 edition = "2018"
 unstable_features = true
-wrap_comments = true


### PR DESCRIPTION
Presently, if you run `cargo fmt` locally on Rust nightly, you end up reformatting all the comments. However, CI doesn't enforce it because it builds using `stable`. We should not set this option until it becomes stable, so ci can enforce consistency.