### PR TITLE
Add TezosClient abstraction

### DIFF
--- a/src/amount.rs
+++ b/src/amount.rs
@@ -91,7 +91,6 @@ impl Amount {
     }
 }
 
-#[allow(unused)]
 #[derive(Debug, Error)]
 pub enum AmountParseError {
     #[error("Unknown currency: {0}")]

--- a/src/bin/customer/close.rs
+++ b/src/bin/customer/close.rs
@@ -42,10 +42,7 @@ enum Error {
 #[async_trait]
 impl Command for Close {
     async fn run(self, mut rng: StdRng, config: self::Config) -> Result<(), anyhow::Error> {
-        let tezos_key_material = config
-            .load_tezos_key_material()
-            .await
-            .context("Failed to load Tezos key material")?;
+        let tezos_key_material = config.load_tezos_key_material()?;
 
         let database = database(&config)
             .await

--- a/src/bin/customer/establish.rs
+++ b/src/bin/customer/establish.rs
@@ -226,7 +226,7 @@ impl Command for Establish {
                 &establishment.merchant_ps_public_key,
                 &tezos_key_material,
                 &channel_id,
-                tezos::DEFAULT_CONFIRMATION_DEPTH,
+                config.confirmation_depth,
                 config.self_delay,
             )
             .await

--- a/src/bin/customer/main.rs
+++ b/src/bin/customer/main.rs
@@ -18,7 +18,7 @@ use zeekoe::{
         defaults::config_path,
         Chan, ChannelName, Cli, Client, Config,
     },
-    escrow::{tezos, types::TezosClient},
+    escrow::types::TezosClient,
     protocol,
 };
 
@@ -177,7 +177,7 @@ pub async fn load_tezos_client(
         uri: Some(config.tezos_uri.clone()),
         contract_id,
         client_key_pair: config.load_tezos_key_material()?,
-        confirmation_depth: tezos::DEFAULT_CONFIRMATION_DEPTH,
+        confirmation_depth: config.confirmation_depth,
         self_delay: config.self_delay,
     })
 }

--- a/src/bin/customer/main.rs
+++ b/src/bin/customer/main.rs
@@ -18,7 +18,7 @@ use zeekoe::{
         defaults::config_path,
         Chan, ChannelName, Cli, Client, Config,
     },
-    escrow::types::TezosClient,
+    escrow::tezos::TezosClient,
     protocol,
 };
 

--- a/src/bin/customer/main.rs
+++ b/src/bin/customer/main.rs
@@ -167,6 +167,7 @@ pub async fn load_tezos_client(
         contract_id,
         client_key_pair: config.load_tezos_key_material()?,
         confirmation_depth: tezos::DEFAULT_CONFIRMATION_DEPTH,
+        self_delay: config.self_delay,
     })
 }
 

--- a/src/bin/customer/watch.rs
+++ b/src/bin/customer/watch.rs
@@ -165,16 +165,9 @@ async fn dispatch_channel(
     {
         // TODO: this should wait for any payments to complete.
 
-        close::unilateral_close(
-            &channel.label,
-            config,
-            off_chain,
-            rng,
-            database,
-            &tezos_key_material,
-        )
-        .await
-        .context("Chain watcher failed to process contract in expiry state")?;
+        close::unilateral_close(&channel.label, config, off_chain, rng, database)
+            .await
+            .context("Chain watcher failed to process contract in expiry state")?;
     }
 
     // The channel has not claimed funds after custClose timeout expired
@@ -186,7 +179,7 @@ async fn dispatch_channel(
         && contract_state.timeout_expired().unwrap_or(false)
         && zkchannels_state::PendingClose.matches(&channel.state)
     {
-        close::claim_funds(database, config, &channel.label, &tezos_key_material)
+        close::claim_funds(database, config, &channel.label)
             .await
             .context("Chain watcher failed to claim funds")?;
         close::finalize_customer_claim(database, &channel.label)

--- a/src/bin/customer/watch.rs
+++ b/src/bin/customer/watch.rs
@@ -26,10 +26,8 @@ impl Command for Watch {
         let config = Arc::new(config);
 
         // Make sure Tezos keys are accessible from disk
-        let _ = config
-            .load_tezos_key_material()
-            .await
-            .context("Customer chain-watching daemon failed to load Tezos key material")?;
+        let key_load_test = config.load_tezos_key_material()?;
+        drop(key_load_test);
 
         /*
         // Note: commenting out the server setup because we will not use it with the polling
@@ -137,10 +135,7 @@ async fn dispatch_channel(
     off_chain: bool,
 ) -> Result<(), anyhow::Error> {
     // Load keys from disk
-    let tezos_key_material = config
-        .load_tezos_key_material()
-        .await
-        .context("Chain watcher failed to load Tezos key material")?;
+    let tezos_key_material = config.load_tezos_key_material()?;
 
     // Retrieve on-chain contract status
     let contract_state = match &channel.contract_details.contract_id {
@@ -191,11 +186,6 @@ async fn dispatch_channel(
         && contract_state.timeout_expired().unwrap_or(false)
         && zkchannels_state::PendingClose.matches(&channel.state)
     {
-        let tezos_key_material = config
-            .load_tezos_key_material()
-            .await
-            .context("Chain watcher failed to load Tezos key material")?;
-
         close::claim_funds(database, config, &channel.label, &tezos_key_material)
             .await
             .context("Chain watcher failed to claim funds")?;

--- a/src/bin/customer/watch.rs
+++ b/src/bin/customer/watch.rs
@@ -11,7 +11,7 @@ use zeekoe::{
         database::{ChannelDetails, QueryCustomer},
         Config,
     },
-    escrow::{tezos, types::ContractStatus},
+    escrow::types::ContractStatus,
 };
 
 use super::{close, database, load_tezos_client, Command, TezosClientError};
@@ -139,7 +139,7 @@ async fn dispatch_channel(
         Err(TezosClientError::ContractDetailsNotSet(_)) => return Ok(()),
         error => error?,
     };
-    let contract_state = tezos::get_contract_state(&tezos_client).await?;
+    let contract_state = tezos_client.get_contract_state().await?;
 
     // The channel has not reacted to an expiry transaction being posted
     // The condition is

--- a/src/bin/merchant/close.rs
+++ b/src/bin/merchant/close.rs
@@ -492,7 +492,6 @@ pub async fn finalize_expiry_close(
 
 /// Compute the new balances if the merchant is called upon to claim all (in case of dispute or
 /// expiry without a close in time).
-#[allow(unused, clippy::diverging_sub_expression)]
 async fn merchant_take_all_balances(
     database: &dyn QueryMerchant,
     channel_id: &ChannelId,

--- a/src/bin/merchant/establish.rs
+++ b/src/bin/merchant/establish.rs
@@ -146,9 +146,6 @@ impl Establish {
 /// Signal to the customer that the channel has been approved to be established, and continue to the
 /// end of the channel establishment protocol.
 #[allow(clippy::too_many_arguments)]
-#[allow(unused)]
-#[allow(clippy::unreachable)]
-#[allow(clippy::diverging_sub_expression)]
 async fn approve_and_establish(
     rng: &mut StdRng,
     database: &dyn QueryMerchant,
@@ -211,7 +208,7 @@ async fn approve_and_establish(
         uri: Some(config.tezos_uri.clone()),
         contract_id: contract_id.clone(),
         client_key_pair: config.load_tezos_key_material()?,
-        confirmation_depth: tezos::DEFAULT_CONFIRMATION_DEPTH,
+        confirmation_depth: 0,
         self_delay: config.self_delay,
     };
     match tezos::establish::verify_origination(

--- a/src/bin/merchant/establish.rs
+++ b/src/bin/merchant/establish.rs
@@ -8,8 +8,8 @@ use zkabacus_crypto::{
 use zeekoe::{
     abort,
     escrow::{
-        tezos,
-        types::{KeyHash, TezosClient, TezosKeyMaterial, TezosPublicKey},
+        tezos::{self, TezosClient},
+        types::{KeyHash, TezosKeyMaterial, TezosPublicKey},
     },
     merchant::{config::Service, database::QueryMerchant, server::SessionKey, Chan, Config},
     offer_abort, proceed,
@@ -208,16 +208,16 @@ async fn approve_and_establish(
         uri: Some(config.tezos_uri.clone()),
         contract_id: contract_id.clone(),
         client_key_pair: config.load_tezos_key_material()?,
-        confirmation_depth: 0,
+        confirmation_depth: config.confirmation_depth,
         self_delay: config.self_delay,
     };
-    match tezos::establish::verify_origination(
-        &proposed_tezos_client,
-        merchant_deposit,
-        customer_deposit,
-        zkabacus_merchant_config.signing_keypair().public_key(),
-    )
-    .await
+    match proposed_tezos_client
+        .verify_origination(
+            merchant_deposit,
+            customer_deposit,
+            zkabacus_merchant_config.signing_keypair().public_key(),
+        )
+        .await
     {
         Ok(()) => {}
         Err(err) => {
@@ -246,7 +246,10 @@ async fn approve_and_establish(
         .context("Failed to receive notification that the customer funded the contract")?;
 
     let tezos_client = load_tezos_client(config, &channel_id, database).await?;
-    match tezos::establish::verify_customer_funding(&tezos_client, &merchant_deposit).await {
+    match tezos_client
+        .verify_customer_funding(&merchant_deposit)
+        .await
+    {
         Ok(()) => {}
         Err(err) => {
             eprintln!("Warning: {}", err);
@@ -272,15 +275,13 @@ async fn approve_and_establish(
     // If the merchant contribution was greater than zero, fund the channel on chain, and await
     // confirmation that the funding has gone through to the required confirmation depth
     if merchant_deposit.into_inner() > 0 {
-        match tezos::establish::add_merchant_funding(
-            &tezos_client,
-            &tezos::establish::MerchantFundingInformation {
+        match tezos_client
+            .add_merchant_funding(&tezos::MerchantFundingInformation {
                 balance: merchant_deposit,
                 public_key: tezos_client.client_key_pair.public_key().clone(),
                 address: tezos_client.client_key_pair.funding_address(),
-            },
-        )
-        .await
+            })
+            .await
         {
             Ok(tezos::OperationStatus::Applied) => {}
             _ => abort!(in chan return establish::Error::FailedMerchantFunding),

--- a/src/bin/merchant/main.rs
+++ b/src/bin/merchant/main.rs
@@ -18,8 +18,8 @@ use std::time::Duration;
 
 use zeekoe::{
     escrow::{
-        tezos,
-        types::{ContractStatus, TezosClient, TezosKeyMaterial},
+        tezos::TezosClient,
+        types::{ContractStatus, TezosKeyMaterial},
     },
     merchant::{
         cli::{self, Run},
@@ -230,7 +230,7 @@ async fn dispatch_channel(
     config: &Config,
 ) -> Result<(), anyhow::Error> {
     let tezos_client = load_tezos_client(config, &channel.channel_id, database).await?;
-    let contract_state = tezos::get_contract_state(&tezos_client).await?;
+    let contract_state = tezos_client.get_contract_state().await?;
 
     // The channel has not claimed funds after the expiry timeout expired
     // The condition is

--- a/src/bin/merchant/main.rs
+++ b/src/bin/merchant/main.rs
@@ -256,14 +256,7 @@ async fn dispatch_channel(
         && contract_state.timeout_expired().unwrap_or(false)
         && channel.status == ChannelStatus::PendingExpiry
     {
-        close::claim_expiry_funds(
-            database,
-            &channel.channel_id,
-            &tezos_key_material,
-            tezos_uri,
-        )
-        .await?;
-
+        close::claim_expiry_funds(config, database, &channel.channel_id).await?;
         close::finalize_expiry_close(database, &channel.channel_id).await?;
     }
 
@@ -288,14 +281,8 @@ async fn dispatch_channel(
                 channel.channel_id
             )
         })?;
-        close::process_customer_close(
-            database,
-            &tezos_key_material,
-            tezos_uri,
-            &channel.channel_id,
-            &revocation_lock,
-        )
-        .await?;
+        close::process_customer_close(config, database, &channel.channel_id, &revocation_lock)
+            .await?;
         close::finalize_customer_close(
             database,
             &channel.channel_id,

--- a/src/bin/merchant/main.rs
+++ b/src/bin/merchant/main.rs
@@ -229,23 +229,8 @@ async fn dispatch_channel(
     channel: &ChannelDetails,
     config: &Config,
 ) -> Result<(), anyhow::Error> {
-    // @FIXME: extract uri, key material from config.
     let tezos_client = load_tezos_client(config, &channel.channel_id, database).await?;
-    let tezos_uri = &tezos_client.uri.unwrap();
-    let tezos_key_material = tezos_client.client_key_pair;
-
-    // Retrieve on-chain contract status
-    let contract_state = tezos::get_contract_state(
-        Some(tezos_uri),
-        &tezos_key_material,
-        &channel.contract_id,
-        tezos_client.confirmation_depth,
-    )
-    .await
-    .context(format!(
-        "Merchant chain watcher failed to retrieve contract state for {}",
-        channel.contract_id
-    ))?;
+    let contract_state = tezos::get_contract_state(&tezos_client).await?;
 
     // The channel has not claimed funds after the expiry timeout expired
     // The condition is

--- a/src/bin/merchant/main.rs
+++ b/src/bin/merchant/main.rs
@@ -337,7 +337,7 @@ pub async fn load_tezos_client(
         uri: Some(config.tezos_uri.clone()),
         contract_id,
         client_key_pair: TezosKeyMaterial::read_key_pair(&config.tezos_account)?,
-        confirmation_depth: tezos::DEFAULT_CONFIRMATION_DEPTH,
+        confirmation_depth: config.confirmation_depth,
         self_delay: config.self_delay,
     })
 }

--- a/src/bin/merchant/parameters.rs
+++ b/src/bin/merchant/parameters.rs
@@ -1,36 +1,23 @@
-use {async_trait::async_trait, http::Uri, rand::rngs::StdRng};
-
 use zeekoe::{
-    escrow::types::TezosKeyMaterial,
-    merchant::{config::Service, database::QueryMerchant, server::SessionKey, Chan},
+    merchant::{Chan, Config},
     protocol,
 };
 
-use super::Method;
-
 pub struct Parameters;
 
-#[async_trait]
-impl Method for Parameters {
-    type Protocol = protocol::Parameters;
-
-    async fn run(
+impl Parameters {
+    pub async fn run(
         &self,
-        _rng: StdRng,
-        _client: &reqwest::Client,
-        tezos_key_material: TezosKeyMaterial,
-        _tezos_uri: Uri,
-        _self_delay: u64,
-        _config: &Service,
+        config: &Config,
         merchant_config: &zkabacus_crypto::merchant::Config,
-        _database: &dyn QueryMerchant,
-        _session_key: SessionKey,
-        chan: Chan<Self::Protocol>,
+        chan: Chan<protocol::Parameters>,
     ) -> Result<(), anyhow::Error> {
         // Extract the components of the merchant's public zkAbacus parameters
         let (public_key, commitment_parameters, range_constraint_parameters) =
             merchant_config.extract_customer_config_parts();
 
+        // Extract public parts of the tezos parameters
+        let tezos_key_material = config.load_tezos_key_material()?;
         let tezos_public_key = tezos_key_material.into_keypair().0;
         let tezos_address = tezos_public_key.hash();
 

--- a/src/config/customer.rs
+++ b/src/config/customer.rs
@@ -64,7 +64,7 @@ impl Config {
         Ok(config)
     }
 
-    pub async fn load_tezos_key_material(&self) -> anyhow::Result<TezosKeyMaterial> {
+    pub fn load_tezos_key_material(&self) -> anyhow::Result<TezosKeyMaterial> {
         Ok(TezosKeyMaterial::read_key_pair(&self.tezos_account)?)
     }
 }

--- a/src/config/customer.rs
+++ b/src/config/customer.rs
@@ -38,6 +38,8 @@ pub struct Config {
     pub tezos_account: KeySpecifier,
     #[serde(default = "defaults::self_delay")]
     pub self_delay: u64,
+    #[serde(default = "defaults::confirmation_depth")]
+    pub confirmation_depth: u64,
     #[serde(default)]
     pub trust_certificate: Option<PathBuf>,
 }

--- a/src/config/merchant.rs
+++ b/src/config/merchant.rs
@@ -7,7 +7,10 @@ use {
 
 pub use super::DatabaseLocation;
 
-use crate::{escrow::types::KeySpecifier, merchant::defaults};
+use crate::{
+    escrow::types::{KeySpecifier, TezosKeyMaterial},
+    merchant::defaults,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
@@ -62,6 +65,10 @@ impl Config {
         }
 
         Ok(config)
+    }
+
+    pub fn load_tezos_key_material(&self) -> Result<TezosKeyMaterial, anyhow::Error> {
+        Ok(TezosKeyMaterial::read_key_pair(&self.tezos_account)?)
     }
 }
 

--- a/src/config/merchant.rs
+++ b/src/config/merchant.rs
@@ -22,6 +22,8 @@ pub struct Config {
     pub tezos_uri: Uri,
     #[serde(default = "defaults::self_delay")]
     pub self_delay: u64,
+    #[serde(default = "defaults::confirmation_depth")]
+    pub confirmation_depth: u64,
     #[serde(rename = "service")]
     pub services: Vec<Service>,
 }

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -30,9 +30,15 @@ pub(crate) mod shared {
         2611
     }
 
+    /// Length of time a party must wait before claiming funds.
     pub const fn self_delay() -> u64 {
         // 2 days, in seconds.
         2 * 24 * 60 * 60
+    }
+
+    /// Depth at which on-chain transactions can be considered finalized.
+    pub const fn confirmation_depth() -> u64 {
+        20
     }
 }
 

--- a/src/escrow/mod.rs
+++ b/src/escrow/mod.rs
@@ -294,38 +294,6 @@ pub mod types {
         KeyFileInvalid(String),
     }
 
-    /// Information that describes a Tezos client that can post a operation on chain.
-    pub struct TezosClient {
-        /// Link to the Tezos network.
-        pub uri: Option<http::Uri>,
-        /// ID of the contract for which the client will post an operation.
-        pub contract_id: ContractId,
-        /// Key material for the client.
-        pub client_key_pair: TezosKeyMaterial,
-        /// Block depth for which the client will wait for their operation to reach.
-        pub confirmation_depth: u64,
-        /// Mutually-agreed delay period for which a client must wait before claiming funds.
-        pub self_delay: u64,
-    }
-
-    impl TezosClient {
-        /// Transforms the Tezos client fields into the correct Python representations, for use in
-        /// inline-python calls to the PyTezos API.
-        ///
-        /// Returns tuple of `(URI, private key, contract_id)`
-        pub fn into_python_types(&self) -> (Option<String>, String, String) {
-            let private_key = self.client_key_pair.private_key().to_base58check();
-            let contract_id = self
-                .contract_id
-                .clone()
-                .to_originated_address()
-                .to_base58check();
-            let uri = self.uri.as_ref().map(|uri| uri.to_string());
-
-            (uri, private_key, contract_id)
-        }
-    }
-
     #[cfg(test)]
     mod test {
         use super::*;

--- a/src/escrow/mod.rs
+++ b/src/escrow/mod.rs
@@ -294,6 +294,36 @@ pub mod types {
         KeyFileInvalid(String),
     }
 
+    /// Information that describes a Tezos client that can post a operation on chain.
+    pub struct TezosClient {
+        /// Link to the Tezos network.
+        pub uri: Option<http::Uri>,
+        /// ID of the contract for which the client will post an operation.
+        pub contract_id: ContractId,
+        /// Key material for the client.
+        pub client_key_pair: TezosKeyMaterial,
+        /// Block depth for which the client will wait for their operation to reach.
+        pub confirmation_depth: u64,
+    }
+
+    impl TezosClient {
+        /// Transforms the Tezos client fields into the correct Python representations, for use in
+        /// inline-python calls to the PyTezos API.
+        ///
+        /// Returns tuple of `(URI, private key, contract_id)`
+        pub fn into_python_types(&self) -> (Option<String>, String, String) {
+            let private_key = self.client_key_pair.private_key().to_base58check();
+            let contract_id = self
+                .contract_id
+                .clone()
+                .to_originated_address()
+                .to_base58check();
+            let uri = self.uri.as_ref().map(|uri| uri.to_string());
+
+            (uri, private_key, contract_id)
+        }
+    }
+
     #[cfg(test)]
     mod test {
         use super::*;

--- a/src/escrow/mod.rs
+++ b/src/escrow/mod.rs
@@ -304,6 +304,8 @@ pub mod types {
         pub client_key_pair: TezosKeyMaterial,
         /// Block depth for which the client will wait for their operation to reach.
         pub confirmation_depth: u64,
+        /// Mutually-agreed delay period for which a client must wait before claiming funds.
+        pub self_delay: u64,
     }
 
     impl TezosClient {

--- a/src/escrow/tezos.rs
+++ b/src/escrow/tezos.rs
@@ -914,19 +914,13 @@ pub mod establish {
     ///
     /// If the expected merchant funding is 0, this operation is invalid if:
     /// - the contract status is not OPEN
-    #[allow(unused)]
     pub fn add_merchant_funding(
-        uri: Option<&http::Uri>,
-        contract_id: &ContractId,
+        tezos_client: &TezosClient,
         merchant_funding_info: &MerchantFundingInformation,
-        merchant_key_pair: &TezosKeyMaterial,
-        confirmation_depth: u64,
     ) -> impl Future<Output = Result<OperationStatus, CustomerFundError>> + Send + 'static {
         let merchant_funding = merchant_funding_info.balance.into_inner();
-        let merchant_private_key = merchant_key_pair.private_key().to_base58check();
-        let merchant_pubkey = merchant_funding_info.public_key.to_base58check();
-        let contract_id = contract_id.clone().to_originated_address().to_base58check();
-        let uri = uri.map(|uri| uri.to_string());
+        let (uri, merchant_private_key, contract_id) = tezos_client.into_python_types();
+        let confirmation_depth = tezos_client.confirmation_depth;
 
         async move {
             tokio::task::spawn_blocking(move || {

--- a/src/escrow/tezos.rs
+++ b/src/escrow/tezos.rs
@@ -22,9 +22,6 @@ lazy_static::lazy_static! {
     static ref CONTRACT_CODE_HASH: ContractHash = ContractHash::new(&*CONTRACT_CODE);
 }
 
-/// The default confirmation depth to consider chain operations to be final.
-pub const DEFAULT_CONFIRMATION_DEPTH: u64 = 20;
-
 /// The default `revocation_lock`: a hex-encoded string which pytezos reads as a scalar 0.
 const DEFAULT_REVOCATION_LOCK: &str = "0x00";
 
@@ -585,9 +582,8 @@ impl FromStr for OperationStatus {
 
 /// Query the chain to retrieve the confirmed state of the contract with the given [`ContractId`].
 ///
-/// This function should query the state of the contract at the given confirmation depth -- that
-/// is, the state of the the contract, but not accounting for the latest
-/// `DEFAULT_CONFIRMATION_DEPTH` blocks.
+/// This function should query the state of the contract at the confirmation depth described in
+/// the `TezosClient`, which may not be the default or "fully confirmed" depth.
 pub fn get_contract_state(
     tezos_client: &TezosClient,
 ) -> impl Future<Output = Result<ContractState, ContractStateError>> + Send + 'static {

--- a/src/escrow/tezos.rs
+++ b/src/escrow/tezos.rs
@@ -741,19 +741,13 @@ pub mod establish {
     /// - the specified customer address does not match the `cust_addr` field in the contract
     /// - the specified funding information does not match the `custFunding` amount in the contract
     /// - the `addFunding` entrypoint has not been called by the customer address before.
-    #[allow(unused)]
     pub fn add_customer_funding(
-        uri: Option<&http::Uri>,
-        contract_id: &ContractId,
+        tezos_client: &TezosClient,
         customer_funding_info: &CustomerFundingInformation,
-        customer_key_pair: &TezosKeyMaterial,
-        confirmation_depth: u64,
-    ) -> impl Future<Output = Result<(OperationStatus), CustomerFundError>> + Send + 'static {
+    ) -> impl Future<Output = Result<OperationStatus, CustomerFundError>> + Send + 'static {
         let customer_funding = customer_funding_info.balance.into_inner();
-        let customer_private_key = customer_key_pair.private_key().to_base58check();
-        let customer_pubkey = customer_funding_info.public_key.to_base58check();
-        let contract_id = contract_id.clone().to_originated_address().to_base58check();
-        let uri = uri.map(|uri| uri.to_string());
+        let (uri, customer_private_key, contract_id) = tezos_client.into_python_types();
+        let confirmation_depth = tezos_client.confirmation_depth;
 
         async move {
             tokio::task::spawn_blocking(move || {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -292,9 +292,7 @@ pub mod close {
         zkabacus_crypto::{CloseState, CloseStateSignature},
     };
 
-    use crate::{
-        database::customer::StateName, escrow::tezos::close::MutualCloseAuthorizationSignature,
-    };
+    use crate::{database::customer::StateName, escrow::tezos::MutualCloseAuthorizationSignature};
 
     use super::*;
 


### PR DESCRIPTION
Per @yaymukund's suggestion, I refactored the Tezos API to use a `TezosClient`, which holds all the Tezos-related values that don't change across the lifetime of a party. This simplifies APIs across the board, and I took out the `Method` trait for the merchant that enforced a lot of unnecessary parameters and didn't add much other value.

Thus, this PR looks large, but it's mostly removing parameter bloat, simplifying APIs, and consolidating queries about tezos information into one place. As an added bonus, this made completion of #221 for confirmation depth quite easy, since we just have to add it to the config files and update the `load_tezos_client` functions, rather than changing code everywhere we call a Tezos API function.

Closes #231
Closes #221 