### PR TITLE
Fix status updates in merchClaim flow

### DIFF
--- a/src/bin/merchant/main.rs
+++ b/src/bin/merchant/main.rs
@@ -287,6 +287,8 @@ async fn dispatch_channel(
             &tezos_uri,
         )
         .await?;
+
+        close::finalize_expiry_close(database, &channel.channel_id).await?;
     }
 
     // The channel has not reacted to a customer posting close balances on chain


### PR DESCRIPTION
fixes 3 status update related bugs
- after claiming money, merchant tried to update from `PendingClose` instead of `PendingMerchantClaim`
- after seeing a successful expiry, customer tried to update from `PendingClose` instead of `PendingExpiry`
- merchant could initiate an expiry from any state, instead of just the valid ones. This would fail on-chain but would make the database status wrong.

closes #246

@indomitableSwan - would like a confirmation of the statuses from which it is valid to initiate expiry
@darius - would like confirmation that this fixes your bug (it does on my end)