### PR TITLE
add dispute functionality to python test

### DIFF
--- a/test-zeekoe.py
+++ b/test-zeekoe.py
@@ -251,7 +251,7 @@ class TestScenario():
 
 COMMANDS = ["list", "merch-setup", "cust-setup", "scenario"]
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("command", help="", nargs="?", default="list")
     parser.add_argument("--path", help="path to create configs", default="./dev")
     parser.add_argument("--network", help="select the type of network", default=SANDBOX)
@@ -261,7 +261,15 @@ def main():
     parser.add_argument("--amount", "-a", help="starting balance for each channel", default="10")
     parser.add_argument("--verbose", "-v", help="increase output verbosity", action="store_true")
     parser.add_argument("--channel", type=int, help="desired starting channel counter", default="1")
-    parser.add_argument('--command-list','-c', nargs='+', help='commands to be tested, e.g. establish pay close')
+    parser.add_argument('--command-list','-c', nargs='+', help='''
+        Commands to be tested. The list of valid commands and their descriptions are:
+        establish - creates a new zkChannel
+        pay - pays the merchant a random amount (at most spending half the remaining balance)
+        pay_all - pays the merchant the full remaining balance in the channel
+        close - performs a customer-initiated unilateral close on the channel
+        store - saves the customer db files in a channel-specific directory under temp_path.
+        restore - restores the customer db files saved during 'store'. This overwrites the existing customer db. 
+        ''')
 
     args = parser.parse_args()
 

--- a/test-zeekoe.py
+++ b/test-zeekoe.py
@@ -8,11 +8,11 @@
 # $: python3 test-zeekoe.py cust-setup --url "http://localhost:20000" -v
 # 
 # Then test the life cycle of a few channels (ideally in parallel): establish a channel, make a payment and run cust close
-# $: python3 test-zeekoe.py scenario --channel 1 -v --command_list establish pay pay pay_all close
+# $: python3 test-zeekoe.py scenario --channel 1 -v --command-list establish pay pay pay_all close
 #
 # To test a dispute scenario, where the customer closes on a revoked state, use 'store' and 
 # 'restore' to restore a revoked state, e.g.
-# $: python3 test-zeekoe.py scenario --channel 1 -v --command_list establish pay store pay restore close
+# $: python3 test-zeekoe.py scenario --channel 1 -v --command-list establish pay store pay restore close
 # 
 # List the channels
 # $: python3 test-zeekoe.py list

--- a/test-zeekoe.py
+++ b/test-zeekoe.py
@@ -192,7 +192,7 @@ class TestScenario():
 
          # Create temporary directory to store revoked customer state when testing dispute scenarios
         if not os.path.isdir(self.temp_path):
-            os.system(f"mkdir {self.temp_path}")
+            os.mkdir(self.temp_path)
 
     def establish(self):
         create_new_channel(self.cust_config, self.channel_name, self.customer_deposit, self.verbose)

--- a/test-zeekoe.py
+++ b/test-zeekoe.py
@@ -149,11 +149,6 @@ def list_channels(cust_config):
     cmd = ["./target/debug/zkchannel", "customer", "--config", cust_config, "list"]
     return run_command(cmd, True)
 
-def scenario_dispute_customer_close(config, channel_name, verbose):
-    # TODO: take necessary steps to close on old state
-    # TODO: then force close as usual
-    pass
-
 def scenario_close_with_expiry(config, channel_name, verbose):
     # TODO: initiate merch expiry
     # TODO: then customer should detect and respond with cust close


### PR DESCRIPTION
Rather than adding a command directly for disputing, I added two commands `store` and `restore` for the customer db so we can be more flexible around which revoked state gets broadcast. e.g.
```
python3 test-zeekoe.py scenario --channel 1 -v --command_list establish pay store pay restore close
python3 test-zeekoe.py scenario --channel 2 -v --command_list establish store pay pay restore close
```
We can also test what happens if the customer attempts to make a payment on a revoked state e.g.
```
python3 test-zeekoe.py scenario --channel 2 -v --command_list establish store pay restore pay
```