### PR TITLE
add expiry test

### DIFF
--- a/test-zeekoe.py
+++ b/test-zeekoe.py
@@ -156,11 +156,6 @@ def expire_channel(merch_config, channel_id, verbose):
     cmd = ["./target/debug/zkchannel", "merchant", "--config", merch_config, "close", "--channel", channel_id]
     return run_command(cmd, verbose)
 
-def scenario_close_with_expiry(config, channel_name, verbose):
-    # TODO: initiate merch expiry
-    # TODO: then customer should detect and respond with cust close
-    pass
-
 def get_blockchain_level(url):
     full_url = url + "/chains/main/blocks/head/metadata"
     r = requests.get(url = full_url)


### PR DESCRIPTION
added `expiry` functionality to the test. 

I left a TODO which is to automatically get the `channel_id` from the `channel_name`. Right now it's tricky because the only way to get the channel name is from the `list` command which outputs a table. This would be straightforward to fix when we have a json output for the `list` command. 

For now, when it gets to `expire`, it'll list the channels and wait for the user to copy and past the channel_id to be expired.