### PR TITLE
Add mutual close

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "arrayvec"
@@ -36,9 +36,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-trait"
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "byteorder"
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 
 [[package]]
 name = "cfg-if"
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10c2722795460108a7872e1cd933a85d6ec38abc4baecad51028f702da28889f"
+checksum = "49fc9a695bca7f35f5f4c15cddc84415f66a74ea78eef08e90c5024f2b540e23"
 dependencies = [
  "crc-catalog",
 ]
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.28"
+version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
+checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
 dependencies = [
  "bytes",
  "fnv",
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes",
  "http",
@@ -877,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.13"
+version = "0.14.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
+checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1095,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "libsodium-sys"
@@ -1172,15 +1172,15 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "minimal-lexical"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c835948974f68e0bd58636fc6c5b1fbff7b297e3046f11b3b3c18bbac012c6d"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
  "libc",
  "log",
@@ -1231,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffd9d26838a953b4af82cbeb9f1592c6798916983959be223a7124e992742c1"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -1360,9 +1360,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.36"
+version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1380,9 +1380,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.67"
+version = "0.9.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
+checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
 dependencies = [
  "autocfg",
  "cc",
@@ -1496,15 +1496,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-crate"
@@ -1554,33 +1554,33 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "protobuf"
-version = "2.25.1"
+version = "2.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23129d50f2c9355ced935fce8a08bd706ee2e7ce2b3b33bf61dace0e379ac63a"
+checksum = "47c327e191621a2158159df97cdbc2e7074bb4e940275e35abf38eb3d2595754"
 
 [[package]]
 name = "protobuf-codegen"
-version = "2.25.1"
+version = "2.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba98ce0dadaa6de1e7f1b6d82a0a73b03e0c049169a167c919d906b0875026c"
+checksum = "3df8c98c08bd4d6653c2dbae00bd68c1d1d82a360265a5b0bbc73d48c63cb853"
 dependencies = [
  "protobuf",
 ]
 
 [[package]]
 name = "protoc"
-version = "2.25.1"
+version = "2.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace5c4ea0e4b0381eb37837e070182b7ab491445e2d5ea2201d861f2b2f94f82"
+checksum = "9ac70cfc8935f5db2a29c0929db697035d02284011a9b78a5ef5d48092ce9673"
 dependencies = [
  "log",
  "which",
@@ -1588,9 +1588,9 @@ dependencies = [
 
 [[package]]
 name = "protoc-rust"
-version = "2.25.1"
+version = "2.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea89f44bc43e185497171242ec4f0d3a79f98010a858f45981775a706d60652"
+checksum = "6bad71c8404e3e09024fccbab55aae36e3662662167dc4530a242c8cc8ef8d20"
 dependencies = [
  "protobuf",
  "protobuf-codegen",
@@ -1648,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -1799,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
+checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
 dependencies = [
  "base64",
  "bytes",
@@ -1889,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f1028de22e436bb35fce070310ee57d57b5e59ae77b4e3f24ce4773312b813"
+checksum = "353775f96a1f400edcca737f843cb201af3645912e741e64456a257c770173e8"
 dependencies = [
  "arrayvec 0.5.2",
  "num-traits",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal_macros"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5732c6adfbb4bbf262b7625832174ef76ccec1786bf8badfcfd11c494214f1a9"
+checksum = "d0847e5bbcded958275518f18a567fea27e53b22b52b549cc3557c88d780b22e"
 dependencies = [
  "quote",
  "rust_decimal",
@@ -1923,8 +1923,20 @@ dependencies = [
  "base64",
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b5ac6078ca424dc1d3ae2328526a76787fecc7f8011f520e3276730e711fc95"
+dependencies = [
+ "log",
+ "ring",
+ "sct 0.7.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -1985,6 +1997,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2063,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062b87e45d8f26714eacfaef0ed9a583e2bfd50ebd96bdd3c200733bd5758e2c"
+checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
 dependencies = [
  "rustversion",
  "serde",
@@ -2074,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c1fcca18d55d1763e1c16873c4bde0ac3ef75179a28c7b372917e0494625be"
+checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2162,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
@@ -2212,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4b94ab0f8c21ee4899b93b06451ef5d965f1a355982ee73684338228498440"
+checksum = "7911b0031a0247af40095838002999c7a52fba29d9739e93326e71a5a1bc9d43"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2222,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec28b91a01e1fe286d6ba66f68289a2286df023fc97444e1fd86c2fd6d5dc026"
+checksum = "aec89bfaca8f7737439bad16d52b07f1ccd0730520d3bf6ae9d069fe4b641fb1"
 dependencies = [
  "ahash",
  "atoi",
@@ -2242,6 +2264,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
+ "indexmap",
  "itoa",
  "libc",
  "libsqlite3-sys",
@@ -2250,7 +2273,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "percent-encoding",
- "rustls",
+ "rustls 0.19.1",
  "serde",
  "sha2",
  "smallvec",
@@ -2260,20 +2283,19 @@ dependencies = [
  "thiserror",
  "tokio-stream",
  "url",
- "webpki",
- "webpki-roots",
+ "webpki 0.21.4",
+ "webpki-roots 0.21.1",
  "whoami",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc33c35d54774eed73d54568d47a6ac099aed8af5e1556a017c131be88217d5"
+checksum = "584866c833511b1a152e87a7ee20dee2739746f60c858b3c5209150bc4b466f5"
 dependencies = [
  "dotenv",
  "either",
- "futures",
  "heck",
  "hex",
  "once_cell",
@@ -2290,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-rt"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14302b678d9c76b28f2e60115211e25e0aabc938269991745a169753dc00e35c"
+checksum = "0d1bd069de53442e7a320f525a6d4deb8bb0621ac7a55f7eccbc2b58b57f43d0"
 dependencies = [
  "once_cell",
  "tokio",
@@ -2329,9 +2351,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
-version = "0.3.23"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
+checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2340,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2377,9 +2399,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.77"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5239bc68e0fef57495900cfea4e8dc75596d9a319d7e16b1e0a440d24e6fe0a0"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2388,9 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2429,18 +2451,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2449,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "thunderdome"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b4947742c93ece24a0032141d9caa3d853752e694a57e35029dd2bd08673e0"
+checksum = "f685624f172cd0bde6f3363412455e81c018f2379fdf5a218e0be003f1bba642"
 
 [[package]]
 name = "time"
@@ -2480,9 +2502,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2500,9 +2522,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154794c8f499c2619acd19e839294703e9e32e7630ef5f46ea80d4ef0fbee5eb"
+checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2525,16 +2547,16 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "rustls",
+ "rustls 0.19.1",
  "tokio",
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2543,9 +2565,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2572,9 +2594,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -2583,9 +2605,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]
@@ -2630,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-normalization"
@@ -2681,20 +2703,20 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3131cd6cb18488da91da1d10ed31e966f453c06b65bf010d35638456976a3fd7"
+checksum = "1dd912a3d096959150c4d71ac752e13f1683085922658c205b89b40fe8ebe07f"
 dependencies = [
  "base64",
  "chunked_transfer",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.20.0",
  "serde",
  "serde_json",
  "url",
- "webpki",
- "webpki-roots",
+ "webpki 0.22.0",
+ "webpki-roots 0.22.1",
 ]
 
 [[package]]
@@ -2788,8 +2810,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -2870,12 +2890,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c475786c6f47219345717a043a37ec04cb4bc185e28853adcc4fa0a947eba630"
+dependencies = [
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -2891,9 +2930,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.1.5"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483a59fee1a93fec90eb08bc2eb4315ef10f4ebc478b3a5fadc969819cb66117"
+checksum = "c33ac5ee236a4efbf2c98967e12c6cc0c51d93a744159a52957ba206ae6ef5f7"
 dependencies = [
  "wasm-bindgen",
  "web-sys",
@@ -2998,26 +3037,26 @@ dependencies = [
  "typenum",
  "url",
  "uuid",
- "webpki",
- "webpki-roots",
+ "webpki 0.21.4",
+ "webpki-roots 0.21.1",
  "zeroize",
  "zkabacus-crypto",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
+checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3028,7 +3067,7 @@ dependencies = [
 [[package]]
 name = "zkabacus-crypto"
 version = "0.1.0"
-source = "git+https://github.com/boltlabs-inc/libzkchannels-crypto.git?branch=main#4ba0927b44e2d28441e98c549dc3c7e3292cf616"
+source = "git+https://github.com/boltlabs-inc/libzkchannels-crypto.git?branch=main#83d60c2bc45d61cc83822aa518ffa5e44144cf34"
 dependencies = [
  "base64",
  "bincode",
@@ -3046,9 +3085,9 @@ dependencies = [
 [[package]]
 name = "zkchannels-crypto"
 version = "0.1.0"
-source = "git+https://github.com/boltlabs-inc/libzkchannels-crypto.git?branch=main#4ba0927b44e2d28441e98c549dc3c7e3292cf616"
+source = "git+https://github.com/boltlabs-inc/libzkchannels-crypto.git?branch=main#83d60c2bc45d61cc83822aa518ffa5e44144cf34"
 dependencies = [
- "arrayvec 0.7.1",
+ "arrayvec 0.7.2",
  "bincode",
  "bls12_381",
  "ff",

--- a/dev/test-zeekoe.py
+++ b/dev/test-zeekoe.py
@@ -148,6 +148,11 @@ def close_channel(cust_config, channel_name, verbose):
     cmd = [ZKCHANNEL_BIN, "customer", "--config", cust_config, "close", "--force", channel_name]
     return run_command(cmd, verbose)
 
+def mutual_close(cust_config, channel_name, verbose):
+    info("Initiate closing on the zkchannel: %s" % channel_name)
+    cmd = [ZKCHANNEL_BIN, "customer", "--config", cust_config, "close", channel_name]
+    return run_command(cmd, verbose)
+
 def list_channels(cust_config):
     info("List channels...")
     cmd = [ZKCHANNEL_BIN, "customer", "--config", cust_config, "list"]
@@ -241,6 +246,12 @@ class TestScenario():
         channel_id = input("Enter the channel_id to be expired\n")
         expire_channel(self.merch_config, channel_id, self.verbose)
 
+    def close(self):
+        close_channel(self.cust_config, self.channel_name, self.verbose)
+
+    def mutual_close(self):
+        mutual_close(self.cust_config, self.channel_name, self.verbose)
+
     def run_command_list(self, command_list):
         for command in command_list:
             if command == "establish":
@@ -257,6 +268,8 @@ class TestScenario():
                 self.restore_state()
             elif command == "expire":
                 self.expire()
+            elif command == "mutual_close":
+                self.mutual_close()
             else:
                 fatal_error(f"{command} not a recognized command.")
 

--- a/src/bin/customer/close.rs
+++ b/src/bin/customer/close.rs
@@ -431,10 +431,10 @@ async fn mutual_close(
         )
         .await;
 
-    // If the mutual close entrypoint call fails due to invalid authorization signature, abort!()
-    if let Err(escrow::types::Error::InvalidAuthorizationSignature(_)) = mutual_close_result {
-        abort!(in chan return close::Error::InvalidMerchantAuthSignature)
-    }
+    // // If the mutual close entrypoint call fails due to invalid authorization signature, abort!()
+    // if let Err(escrow::types::Error::InvalidAuthorizationSignature(_)) = mutual_close_result {
+    //     abort!(in chan return close::Error::InvalidMerchantAuthSignature)
+    // }
 
     // Otherwise, close the dialectic channel...
     proceed!(in chan);

--- a/src/bin/customer/close.rs
+++ b/src/bin/customer/close.rs
@@ -427,7 +427,7 @@ async fn mutual_close(
             close_state.channel_id(),
             close_state.customer_balance(),
             close_state.merchant_balance(),
-            &authorization_signature,
+            authorization_signature,
         )
         .await;
 

--- a/src/bin/customer/close.rs
+++ b/src/bin/customer/close.rs
@@ -424,7 +424,6 @@ async fn mutual_close(
     let tezos_client = load_tezos_client(&config, &close.label, database.as_ref()).await?;
     let mutual_close_result = tezos_client
         .mutual_close(
-            close_state.channel_id(),
             close_state.customer_balance(),
             close_state.merchant_balance(),
             authorization_signature,

--- a/src/bin/customer/close.rs
+++ b/src/bin/customer/close.rs
@@ -422,7 +422,8 @@ async fn mutual_close(
 
     // Verify the authorization siganture under the merchant's EdDSA Tezos key
     let tezos_client = load_tezos_client(&config, &close.label, database.as_ref()).await?;
-    let merchant_tezos_public_key = channel_details.contract_details.merchant_tezos_public_key;    let verification_result = tezos_client
+    let merchant_tezos_public_key = channel_details.contract_details.merchant_tezos_public_key;
+    let verification_result = tezos_client
         .verify_authorization_signature(
             close_state.channel_id(),
             &merchant_tezos_public_key,

--- a/src/bin/customer/close.rs
+++ b/src/bin/customer/close.rs
@@ -435,7 +435,11 @@ async fn mutual_close(
 
     // If authorization signature is invalid, abort!()
     match verification_result {
-        Ok(()) => (),
+        Ok(()) => {
+            // Close the dialectic channel...
+            proceed!(in chan);
+            chan.close();
+        },
         Err(_) => abort!(in chan return close::Error::InvalidMerchantAuthorizationSignature),
     }
 
@@ -447,10 +451,6 @@ async fn mutual_close(
             &authorization_signature,
         )
         .await;
-
-    // Close the dialectic channel...
-    proceed!(in chan);
-    chan.close();
 
     // ...and raise the appropriate error if one exists.
     // The customer has the option to retry or initiate a unilateral close.

--- a/src/bin/merchant/close.rs
+++ b/src/bin/merchant/close.rs
@@ -48,8 +48,7 @@ impl Close {
         let authorization_signature = tezos_client
             .authorize_mutual_close(&close_state)
             .await
-            .context("Failed to produce mutual close authorization signature")?
-            .into();
+            .context("Failed to produce mutual close authorization signature")?;
 
         let chan = chan
             .send(authorization_signature)

--- a/src/bin/merchant/close.rs
+++ b/src/bin/merchant/close.rs
@@ -47,7 +47,8 @@ impl Close {
         let tezos_client = load_tezos_client(config, close_state.channel_id(), database).await?;
         let authorization_signature = tezos_client
             .authorize_mutual_close(&close_state)
-            .context("Failed to post mutualClose entrypoint")?
+            .await
+            .context("Failed to produce mutual close authorization signature")?
             .into();
 
         let chan = chan

--- a/src/escrow/mod.rs
+++ b/src/escrow/mod.rs
@@ -287,8 +287,6 @@ pub mod types {
         InvalidZkChannelsContract(ContractId),
         #[error("Failed to produce an authorization signature for mutual close operation for contract ID {0}")]
         SigningFailed(ContractId),
-        #[error("Mutual close authorization signature is invalid for contract ID {0}")]
-        InvalidAuthorizationSignature(ContractId),
         #[error("Key file was invalid: {0}")]
         KeyFileInvalid(String),
     }

--- a/src/escrow/tezos.rs
+++ b/src/escrow/tezos.rs
@@ -339,16 +339,16 @@ fn python_context() -> inline_python::Context {
             merch_py = pytezos.using(key=merch_pubkey, shell=uri)
             // Specify the structure and types of the fields going into the mutual close state.
             ty = MichelsonType.match(michelson_to_micheline("pair (pair bls12_381_fr string) (pair address (pair mutez mutez))"))
-            // create the packed (serialized) version of the mutual close state, corresponding to 
-            // the types above. "legacy=True" ensures pytezos will always serialize the data as in 
-            // michelson rather than micheline. 
+            // create the packed (serialized) version of the mutual close state, corresponding to
+            // the types above. "legacy=True" ensures pytezos will always serialize the data as in
+            // michelson rather than micheline.
             packed = ty.from_python_object((channel_id, "zkChannels mutual close", contract_id, customer_balance, merchant_balance)).pack(legacy=True).hex()
 
             // merch_py.key.verify() throws an error if the signature is invalid
             merch_py.key.verify(authorization_signature, packed)
 
-            return 
-            
+            return
+
         def mutual_close(
             uri,
             cust_acc,
@@ -1335,15 +1335,13 @@ impl TezosClient {
         customer_balance: &CustomerBalance,
         merchant_balance: &MerchantBalance,
         authorization_signature: &MutualCloseAuthorizationSignature,
-    ) -> impl Future<Output = Result<(), InvalidAuthorizationSignatureError>>
-           + Send
-           + 'static {
-            let (uri, _, contract_id) = self.as_python_types();
-            let merchant_pubkey = merchant_pubkey.to_base58check();
-            let channel_id = hex_string(&channel_id.to_bytes());
-            let customer_balance = customer_balance.into_inner();
-            let merchant_balance = merchant_balance.into_inner();
-            let authorization_signature = authorization_signature.signature.clone();
+    ) -> impl Future<Output = Result<(), InvalidAuthorizationSignatureError>> + Send + 'static {
+        let (uri, _, contract_id) = self.as_python_types();
+        let merchant_pubkey = merchant_pubkey.to_base58check();
+        let channel_id = hex_string(&channel_id.to_bytes());
+        let customer_balance = customer_balance.into_inner();
+        let merchant_balance = merchant_balance.into_inner();
+        let authorization_signature = authorization_signature.signature.clone();
 
         async move {
             tokio::task::spawn_blocking(move || {

--- a/src/escrow/tezos.rs
+++ b/src/escrow/tezos.rs
@@ -320,11 +320,11 @@ fn python_context() -> inline_python::Context {
             merch_py = pytezos.using(key=merch_acc, shell=uri)
             // Specify the structure and types of the fields going into the mutual close state.
             ty = MichelsonType.match(michelson_to_micheline("pair (pair bls12_381_fr string) (pair address (pair mutez mutez))"))
-            // create the packed (serialized) version of the mutual close state, corresponding to the types above. 
-            // legacy=True ensures pytezos will always serialize the data as in michelson rather than micheline. 
+            // create the packed (serialized) version of the mutual close state, corresponding to the types above.
+            // legacy=True ensures pytezos will always serialize the data as in michelson rather than micheline.
             packed = ty.from_python_object((channel_id, "zkChannels mutual close", contract_id, customer_balance, merchant_balance)).pack(legacy=True).hex()
             mutual_close_signature = merch_py.key.sign(packed)
-            
+
             return mutual_close_signature
 
         def mutual_close(
@@ -1279,8 +1279,8 @@ impl TezosClient {
             )
         });
 
-        let mutual_close_signature = MutualCloseAuthorizationSignature{
-            signature: context.get::<String>("out")
+        let mutual_close_signature = MutualCloseAuthorizationSignature {
+            signature: context.get::<String>("out"),
         };
         Ok(mutual_close_signature)
     }
@@ -1330,7 +1330,6 @@ impl TezosClient {
             .await
             .map_err(MutualCloseError)
         }
-
     }
 
     /// Verify that the specified contract is closed.

--- a/src/escrow/tezos.rs
+++ b/src/escrow/tezos.rs
@@ -1310,7 +1310,6 @@ impl TezosClient {
     #[allow(unused)]
     pub fn mutual_close(
         &self,
-        channel_id: &ChannelId,
         customer_balance: &CustomerBalance,
         merchant_balance: &MerchantBalance,
         authorization_signature: MutualCloseAuthorizationSignature,

--- a/src/escrow/tezos.rs
+++ b/src/escrow/tezos.rs
@@ -323,16 +323,16 @@ fn python_context() -> inline_python::Context {
             // create the packed (serialized) version of the mutual close state, corresponding to the types above.
             // legacy=True ensures pytezos will always serialize the data as in michelson rather than micheline.
             packed = ty.from_python_object((channel_id, "zkChannels mutual close", contract_id, customer_balance, merchant_balance)).pack(legacy=True).hex()
-            mutual_close_signature = merch_py.key.sign(packed)
+            authorization_signature = merch_py.key.sign(packed)
 
-            return mutual_close_signature
+            return authorization_signature
 
         def mutual_close(
             uri,
             cust_acc,
             contract_id,
             customer_balance, merchant_balance,
-            mutual_close_signature,
+            authorization_signature,
             min_confirmations,
         ):
             // Customer pytezos interface
@@ -345,7 +345,7 @@ fn python_context() -> inline_python::Context {
             mutual_close_storage = {
                 "customer_balance": int(customer_balance),
                 "merchant_balance": int(merchant_balance),
-                "merchSig": mutual_close_signature
+                "merchSig": authorization_signature
             }
 
             // Call the mutualClose entrypoint
@@ -1319,7 +1319,7 @@ impl TezosClient {
         let customer_balance = customer_balance.into_inner();
         let merchant_balance = merchant_balance.into_inner();
         let confirmation_depth = self.confirmation_depth;
-        let mutual_close_signature = authorization_signature.signature;
+        let authorization_signature = authorization_signature.signature;
         async move {
             tokio::task::spawn_blocking(move || {
                 let context = python_context();
@@ -1330,7 +1330,7 @@ impl TezosClient {
                         'contract_id,
                         'customer_balance,
                         'merchant_balance,
-                        'mutual_close_signature,
+                        'authorization_signature,
                         'confirmation_depth
                     )
                 });

--- a/src/escrow/tezos.rs
+++ b/src/escrow/tezos.rs
@@ -32,6 +32,10 @@ const DEFAULT_REVOCATION_LOCK: &str = "0x00";
 /// functions without the Global Interpreter Lock.
 fn python_context() -> inline_python::Context {
     let context = python! {
+
+        // For documentation about the pytezos library: https://pytezos.org
+        // Producing and verifying the signature for mutual close uses the methods
+        // listed in https://pytezos.org/crypto.html
         import json
         from pytezos import pytezos, Contract, ContractInterface
         from pytezos.michelson.types import MichelsonType
@@ -1286,7 +1290,6 @@ impl TezosClient {
     /// `(contract id, "zkChannels mutual close", channel id, customer balance, merchant balance)`
     ///
     /// This is called by the merchant.
-    #[allow(unused)]
     pub fn authorize_mutual_close(
         &self,
         close_state: &CloseState,
@@ -1327,7 +1330,6 @@ impl TezosClient {
     /// `(contract id, "zkChannels mutual close", channel id, customer balance, merchant balance)`
     ///
     /// This is called by the customer.
-    #[allow(unused)]
     pub fn verify_authorization_signature(
         &self,
         channel_id: &ChannelId,
@@ -1374,7 +1376,6 @@ impl TezosClient {
     /// - the [`TezosKeyPair`] does not match the `cust_addr` field in the specified contract
     /// - the `authorization_signature` is not a valid signature under the merchant public key
     ///   on the expected tuple
-    #[allow(unused)]
     pub fn mutual_close(
         &self,
         customer_balance: &CustomerBalance,

--- a/src/escrow/tezos.rs
+++ b/src/escrow/tezos.rs
@@ -1313,13 +1313,13 @@ impl TezosClient {
         channel_id: &ChannelId,
         customer_balance: &CustomerBalance,
         merchant_balance: &MerchantBalance,
-        authorization_signature: &MutualCloseAuthorizationSignature,
+        authorization_signature: MutualCloseAuthorizationSignature,
     ) -> impl Future<Output = Result<OperationStatus, MutualCloseError>> + Send + 'static {
         let (uri, customer_private_key, contract_id) = self.as_python_types();
         let customer_balance = customer_balance.into_inner();
         let merchant_balance = merchant_balance.into_inner();
         let confirmation_depth = self.confirmation_depth;
-        let mutual_close_signature = authorization_signature.signature.clone();
+        let mutual_close_signature = authorization_signature.signature;
         async move {
             tokio::task::spawn_blocking(move || {
                 let context = python_context();

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -305,7 +305,7 @@ pub mod close {
         #[error("Customer sent a close state that has already been seen")]
         KnownRevocationLock,
         #[error("Merchant send an invalid authorization signature")]
-        InvalidMerchantAuthSignature,
+        InvalidMerchantAuthorizationSignature,
         #[error("Arbiter failed to accept mutual close")]
         ArbiterRejectedMutualClose,
     }


### PR DESCRIPTION
fill in todos for:
- `authorize_mutual_close`
- `mutual_close`

I tested it and it worked - the transaction went through and the channel status was set to `closed`.

Remaining todo I wasn't sure how to handle:
I created `MutualCloseError` so that `mutual_close` would return an error consistent with the other contract call operations. I then commented out the abort condition when getting `InvalidAuthorizationSignature` (close.rs L434) because I'm not sure how the error types work.