### PR TITLE
`max_connections(1)` to avoid using multiple writers w sqlite.

### DIFF
--- a/src/database/customer.rs
+++ b/src/database/customer.rs
@@ -844,7 +844,10 @@ mod tests {
     use zkabacus_crypto::{customer::*, merchant, *};
 
     async fn create_migrated_db() -> Result<SqlitePool> {
-        let conn = SqlitePoolOptions::new().connect("sqlite::memory:").await?;
+        let conn = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await?;
         conn.migrate().await?;
         Ok(conn)
     }

--- a/src/database/merchant.rs
+++ b/src/database/merchant.rs
@@ -678,7 +678,10 @@ mod tests {
     }
 
     async fn create_migrated_db() -> Result<SqlitePool> {
-        let conn = SqlitePoolOptions::new().connect("sqlite::memory:").await?;
+        let conn = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await?;
         conn.migrate().await?;
         Ok(conn)
     }


### PR DESCRIPTION
Closes #223 

It is not supported. See: https://sqlite.org/wal.html#concurrency

"However, since there is only one WAL file, there can only be one writer
at a time."