### PR TITLE
Add timeouts to pay

### DIFF
--- a/src/bin/merchant/pay.rs
+++ b/src/bin/merchant/pay.rs
@@ -102,7 +102,7 @@ async fn provide_service(
     }
 }
 
-/// The core zkAbacus.Pay protocol: update the channel state by the payment amount.
+/// The core zkAbacus.Pay protocol: provide the customer with a valid, updated channel state.
 async fn zkabacus_pay(
     mut rng: StdRng,
     database: &dyn QueryMerchant,

--- a/src/cli/customer.rs
+++ b/src/cli/customer.rs
@@ -209,6 +209,12 @@ impl FromStr for Note {
     }
 }
 
+impl Default for Note {
+    fn default() -> Self {
+        Note::String(String::from(""))
+    }
+}
+
 impl Note {
     pub fn read(self, max_length: u64) -> Result<String, io::Error> {
         match self {

--- a/src/config/customer.rs
+++ b/src/config/customer.rs
@@ -29,6 +29,10 @@ pub struct Config {
     pub daemon_port: u16,
     #[serde(default = "defaults::max_pending_connection_retries")]
     pub max_pending_connection_retries: usize,
+    #[serde(default = "defaults::message_timeout")]
+    pub message_timeout: u64,
+    #[serde(default = "defaults::approval_timeout")]
+    pub approval_timeout: u64,
     #[serde(default = "defaults::max_message_length")]
     pub max_message_length: usize,
     #[serde(default = "defaults::max_note_length")]

--- a/src/config/customer.rs
+++ b/src/config/customer.rs
@@ -85,4 +85,12 @@ impl Config {
     pub fn load_tezos_key_material(&self) -> anyhow::Result<TezosKeyMaterial> {
         Ok(TezosKeyMaterial::read_key_pair(&self.tezos_account)?)
     }
+
+    pub fn message_timeout(&self) -> Duration {
+        Duration::from_secs(self.message_timeout)
+    }
+
+    pub fn approval_timeout(&self) -> Duration {
+        Duration::from_secs(self.approval_timeout)
+    }
 }

--- a/src/config/customer.rs
+++ b/src/config/customer.rs
@@ -29,10 +29,10 @@ pub struct Config {
     pub daemon_port: u16,
     #[serde(default = "defaults::max_pending_connection_retries")]
     pub max_pending_connection_retries: usize,
-    #[serde(default = "defaults::message_timeout")]
-    pub message_timeout: u64,
-    #[serde(default = "defaults::approval_timeout")]
-    pub approval_timeout: u64,
+    #[serde(with = "humantime_serde", default = "defaults::message_timeout")]
+    pub message_timeout: Duration,
+    #[serde(with = "humantime_serde", default = "defaults::approval_timeout")]
+    pub approval_timeout: Duration,
     #[serde(default = "defaults::max_message_length")]
     pub max_message_length: usize,
     #[serde(default = "defaults::max_note_length")]
@@ -84,13 +84,5 @@ impl Config {
 
     pub fn load_tezos_key_material(&self) -> anyhow::Result<TezosKeyMaterial> {
         Ok(TezosKeyMaterial::read_key_pair(&self.tezos_account)?)
-    }
-
-    pub fn message_timeout(&self) -> Duration {
-        Duration::from_secs(self.message_timeout)
-    }
-
-    pub fn approval_timeout(&self) -> Duration {
-        Duration::from_secs(self.approval_timeout)
     }
 }

--- a/src/config/merchant.rs
+++ b/src/config/merchant.rs
@@ -46,10 +46,10 @@ pub struct Service {
     pub connection_timeout: Option<Duration>,
     #[serde(default = "defaults::max_pending_connection_retries")]
     pub max_pending_connection_retries: usize,
-    #[serde(default = "defaults::message_timeout")]
-    pub message_timeout: u64,
-    #[serde(default = "defaults::transaction_timeout")]
-    pub transaction_timeout: u64,
+    #[serde(with = "humantime_serde", default = "defaults::message_timeout")]
+    pub message_timeout: Duration,
+    #[serde(with = "humantime_serde", default = "defaults::transaction_timeout")]
+    pub transaction_timeout: Duration,
     #[serde(default = "defaults::max_message_length")]
     pub max_message_length: usize,
     #[serde(default)]
@@ -87,16 +87,6 @@ impl Config {
 
     pub fn load_tezos_key_material(&self) -> Result<TezosKeyMaterial, anyhow::Error> {
         Ok(TezosKeyMaterial::read_key_pair(&self.tezos_account)?)
-    }
-}
-
-impl Service {
-    pub fn message_timeout(&self) -> Duration {
-        Duration::from_secs(self.message_timeout)
-    }
-
-    pub fn transaction_timeout(&self) -> Duration {
-        Duration::from_secs(self.transaction_timeout)
     }
 }
 

--- a/src/config/merchant.rs
+++ b/src/config/merchant.rs
@@ -46,6 +46,10 @@ pub struct Service {
     pub connection_timeout: Option<Duration>,
     #[serde(default = "defaults::max_pending_connection_retries")]
     pub max_pending_connection_retries: usize,
+    #[serde(default = "defaults::message_timeout")]
+    pub message_timeout: u64,
+    #[serde(default = "defaults::transaction_timeout")]
+    pub transaction_timeout: u64,
     #[serde(default = "defaults::max_message_length")]
     pub max_message_length: usize,
     #[serde(default)]

--- a/src/config/merchant.rs
+++ b/src/config/merchant.rs
@@ -90,6 +90,16 @@ impl Config {
     }
 }
 
+impl Service {
+    pub fn message_timeout(&self) -> Duration {
+        Duration::from_secs(self.message_timeout)
+    }
+
+    pub fn transaction_timeout(&self) -> Duration {
+        Duration::from_secs(self.transaction_timeout)
+    }
+}
+
 /// A description of how to approve payments.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -14,6 +14,8 @@ fn project_dirs() -> Result<ProjectDirs, anyhow::Error> {
 }
 
 pub(crate) mod shared {
+    use super::*;
+
     pub const ORGANIZATION: &str = "Bolt Labs";
 
     pub const APPLICATION: &str = "zkchannel";
@@ -42,8 +44,8 @@ pub(crate) mod shared {
     }
 
     /// Length of time (seconds) that a party waits for a normal message to be computed and sent.
-    pub const fn message_timeout() -> u64 {
-        60
+    pub const fn message_timeout() -> Duration {
+        Duration::from_secs(60)
     }
 }
 
@@ -64,8 +66,8 @@ pub mod merchant {
 
     /// Length of time (seconds) that a merchant waits for the customer to post and confirm a
     /// transaction on Tezos.
-    pub const fn transaction_timeout() -> u64 {
-        25 * 60
+    pub const fn transaction_timeout() -> Duration {
+        Duration::from_secs(25 * 60)
     }
 }
 
@@ -113,7 +115,7 @@ pub mod customer {
 
     /// Length of time (seconds) that a customer waits for the merchant to approve a new channel
     /// or a payment.
-    pub const fn approval_timeout() -> u64 {
-        360
+    pub const fn approval_timeout() -> Duration {
+        Duration::from_secs(360)
     }
 }

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -40,6 +40,11 @@ pub(crate) mod shared {
     pub const fn confirmation_depth() -> u64 {
         20
     }
+
+    /// Length of time (seconds) that a party waits for a normal message to be computed and sent.
+    pub const fn message_timeout() -> u64 {
+        60
+    }
 }
 
 pub mod merchant {
@@ -55,6 +60,12 @@ pub mod merchant {
 
     pub fn config_path() -> Result<PathBuf, anyhow::Error> {
         Ok(project_dirs()?.config_dir().join(CONFIG_FILE))
+    }
+
+    /// Length of time (seconds) that a merchant waits for the customer to post and confirm a
+    /// transaction on Tezos.
+    pub const fn transaction_timeout() -> u64 {
+        25 * 60
     }
 }
 
@@ -98,5 +109,11 @@ pub mod customer {
     pub const fn daemon_port() -> u16 {
         // ZKD :3
         26114
+    }
+
+    /// Length of time (seconds) that a customer waits for the merchant to approve a new channel
+    /// or a payment.
+    pub const fn approval_timeout() -> u64 {
+        360
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod customer;
 pub mod escrow;
 pub mod merchant;
 pub mod protocol;
+pub mod timeout;
 
 mod cli;
 mod config;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -356,6 +356,10 @@ pub mod pay {
     pub type Pay = Session! {
         send PaymentAmount;
         send String; // Payment note
+        GetPaymentApproval;
+    };
+
+    pub type GetPaymentApproval = Session! {
         // Merchant decides if it wants to allow the described payment
         OfferAbort<CustomerStartPayment, Error>;
     };

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -1,0 +1,17 @@
+use {async_trait::async_trait, futures::Future, std::time::Duration, tokio::time::Timeout};
+
+#[async_trait]
+pub trait WithTimeout {
+    fn with_timeout(self, duration: Duration) -> Timeout<Self>
+    where
+        Self: Sized;
+}
+
+impl<T> WithTimeout for T
+where
+    T: Future + Sized,
+{
+    fn with_timeout(self, duration: Duration) -> Timeout<Self> {
+        tokio::time::timeout(duration, self)
+    }
+}


### PR DESCRIPTION
This PR does the following:
- add default timeouts to customer and merchant configs
- refactor Pay for both parties into more logical code blocks
- add appropriate timeouts to code blocks that require waiting for the other party

Addresses but does not finish #114.