### PR TITLE
Add verified revocation pair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,7 +3067,7 @@ dependencies = [
 [[package]]
 name = "zkabacus-crypto"
 version = "0.1.0"
-source = "git+https://github.com/boltlabs-inc/libzkchannels-crypto.git?branch=add-verified-revocation-pair#4a77d6b4537bd196ecc7abe4dc2de0bedb51a2cd"
+source = "git+https://github.com/boltlabs-inc/libzkchannels-crypto.git#4a77d6b4537bd196ecc7abe4dc2de0bedb51a2cd"
 dependencies = [
  "base64",
  "bincode",
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "zkchannels-crypto"
 version = "0.1.0"
-source = "git+https://github.com/boltlabs-inc/libzkchannels-crypto.git?branch=add-verified-revocation-pair#4a77d6b4537bd196ecc7abe4dc2de0bedb51a2cd"
+source = "git+https://github.com/boltlabs-inc/libzkchannels-crypto.git#4a77d6b4537bd196ecc7abe4dc2de0bedb51a2cd"
 dependencies = [
  "arrayvec 0.7.2",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
@@ -806,9 +806,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hidapi"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e07da7e8614133e88b3a93b7352eb3729e3ccd82d5ab661adf23bef1761bf8"
+checksum = "4f39cbe399e8e9550264e9f26553bf26f5ece2b6cf13abe32d06c857a5166263"
 dependencies = [
  "cc",
  "libc",
@@ -1929,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5ac6078ca424dc1d3ae2328526a76787fecc7f8011f520e3276730e711fc95"
+checksum = "dac4581f0fc0e0efd529d069e8189ec7b90b8e7680e21beb35141bdc45f36040"
 dependencies = [
  "log",
  "ring",
@@ -2061,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
+checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2502,9 +2502,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "52963f91310c08d91cb7bff5786dfc8b79642ab839e188187e92105dbfb9d2c8"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2703,15 +2703,15 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd912a3d096959150c4d71ac752e13f1683085922658c205b89b40fe8ebe07f"
+checksum = "c5c448dcb78ec38c7d59ec61f87f70a98ea19171e06c139357e012ee226fec90"
 dependencies = [
  "base64",
  "chunked_transfer",
  "log",
  "once_cell",
- "rustls 0.20.0",
+ "rustls 0.20.1",
  "serde",
  "serde_json",
  "url",
@@ -3067,7 +3067,7 @@ dependencies = [
 [[package]]
 name = "zkabacus-crypto"
 version = "0.1.0"
-source = "git+https://github.com/boltlabs-inc/libzkchannels-crypto.git?branch=add-verified-revocation-pair#3b4b19fde4145b966f30715bc91a0da85914b4d1"
+source = "git+https://github.com/boltlabs-inc/libzkchannels-crypto.git?branch=add-verified-revocation-pair#4a77d6b4537bd196ecc7abe4dc2de0bedb51a2cd"
 dependencies = [
  "base64",
  "bincode",
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "zkchannels-crypto"
 version = "0.1.0"
-source = "git+https://github.com/boltlabs-inc/libzkchannels-crypto.git?branch=add-verified-revocation-pair#3b4b19fde4145b966f30715bc91a0da85914b4d1"
+source = "git+https://github.com/boltlabs-inc/libzkchannels-crypto.git?branch=add-verified-revocation-pair#4a77d6b4537bd196ecc7abe4dc2de0bedb51a2cd"
 dependencies = [
  "arrayvec 0.7.2",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,7 +3067,7 @@ dependencies = [
 [[package]]
 name = "zkabacus-crypto"
 version = "0.1.0"
-source = "git+https://github.com/boltlabs-inc/libzkchannels-crypto.git?branch=main#dc66beb3975e0b7cb13d19f3f1880a3406ecaf4f"
+source = "git+https://github.com/boltlabs-inc/libzkchannels-crypto.git?branch=add-verified-revocation-pair#3b4b19fde4145b966f30715bc91a0da85914b4d1"
 dependencies = [
  "base64",
  "bincode",
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "zkchannels-crypto"
 version = "0.1.0"
-source = "git+https://github.com/boltlabs-inc/libzkchannels-crypto.git?branch=main#dc66beb3975e0b7cb13d19f3f1880a3406ecaf4f"
+source = "git+https://github.com/boltlabs-inc/libzkchannels-crypto.git?branch=add-verified-revocation-pair#3b4b19fde4145b966f30715bc91a0da85914b4d1"
 dependencies = [
  "arrayvec 0.7.2",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/bin/merchant/main.rs"
 allow_explicit_certificate_trust = []
 
 [dependencies]
-zkabacus-crypto = { git = "https://github.com/boltlabs-inc/libzkchannels-crypto.git", branch = "add-verified-revocation-pair", features = ["sqlite"] }
+zkabacus-crypto = { git = "https://github.com/boltlabs-inc/libzkchannels-crypto.git", features = ["sqlite"] }
 tokio = { version = "1", features = ["full"] }
 tokio-rustls = "0.22"
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/bin/merchant/main.rs"
 allow_explicit_certificate_trust = []
 
 [dependencies]
-zkabacus-crypto = { git = "https://github.com/boltlabs-inc/libzkchannels-crypto.git", branch = "main", features = ["sqlite"] }
+zkabacus-crypto = { git = "https://github.com/boltlabs-inc/libzkchannels-crypto.git", branch = "add-verified-revocation-pair", features = ["sqlite"] }
 tokio = { version = "1", features = ["full"] }
 tokio-rustls = "0.22"
 anyhow = "1"

--- a/src/bin/customer/close.rs
+++ b/src/bin/customer/close.rs
@@ -125,7 +125,7 @@ pub async fn unilateral_close(
             merchant_balance: *close_message.merchant_balance(),
             customer_balance: *close_message.customer_balance(),
             closing_signature: close_message.closing_signature().clone(),
-            revocation_lock: close_message.revocation_lock().clone(),
+            revocation_lock: *close_message.revocation_lock(),
             channel_id: *close_message.channel_id(),
         };
         write_close_json(&closing)?;

--- a/src/bin/customer/pay.rs
+++ b/src/bin/customer/pay.rs
@@ -176,12 +176,9 @@ async fn zkabacus_pay(
 
         // If the closing signature verifies, reveal our lock, secret, and blinding factor
         let chan = chan
-            .send(lock_message.revocation_lock)
+            .send(lock_message.revocation_pair)
             .await
-            .context("Failed to send revocation lock")?
-            .send(lock_message.revocation_secret)
-            .await
-            .context("Failed to send revocation secret")?
+            .context("Failed to send revocation pair")?
             .send(lock_message.revocation_lock_blinding_factor)
             .await
             .context("Failed to send revocation lock blinding factor")?;

--- a/src/bin/merchant/close.rs
+++ b/src/bin/merchant/close.rs
@@ -106,7 +106,7 @@ pub async fn process_customer_close(
     // Save the provided revocation lock (from the entrypoint call) and retrieve any existing
     // revocation secrets associated with it.
     let possible_secrets = database
-        .insert_revocation(revocation_lock, None)
+        .insert_revocation_lock(revocation_lock)
         .await
         .context(format!(
             "Failed to look up revocation lock (id: {})",
@@ -334,7 +334,7 @@ async fn zkabacus_close(
         Verification::Verified => {
             // Check that the revocation lock is fresh and insert
             if database
-                .insert_revocation(close_state.revocation_lock(), None)
+                .insert_revocation_lock(close_state.revocation_lock())
                 .await
                 .context("Failed to insert revocation lock into database")?
                 .is_empty()

--- a/src/bin/merchant/close.rs
+++ b/src/bin/merchant/close.rs
@@ -7,7 +7,7 @@ use zeekoe::{
     abort,
     merchant::{
         cli,
-        database::{Error, QueryMerchant},
+        database::{Error, QueryMerchant, QueryMerchantExt},
         Chan, Config,
     },
     offer_abort, proceed,

--- a/src/bin/merchant/pay.rs
+++ b/src/bin/merchant/pay.rs
@@ -165,10 +165,7 @@ async fn zkabacus_pay(
             {
                 // Check to see if the revocation lock was already present in the database
                 let prior_revocations = database
-                    .insert_revocation(
-                        &revocation_pair.revocation_lock(),
-                        Some(&revocation_pair.revocation_secret()),
-                    )
+                    .insert_revocation_pair(&revocation_pair)
                     .await
                     .context("Failed to insert revocation lock/secret pair in database")?;
 

--- a/src/bin/merchant/pay.rs
+++ b/src/bin/merchant/pay.rs
@@ -2,7 +2,12 @@ use {anyhow::Context, rand::rngs::StdRng, url::Url};
 
 use zeekoe::{
     abort,
-    merchant::{config::Service, database::QueryMerchant, server::SessionKey, Chan},
+    merchant::{
+        config::Service,
+        database::{QueryMerchant, QueryMerchantExt},
+        server::SessionKey,
+        Chan,
+    },
     offer_abort, proceed,
     protocol::{self, pay, Party::Merchant},
     timeout::WithTimeout,

--- a/src/database/merchant.rs
+++ b/src/database/merchant.rs
@@ -21,6 +21,10 @@ pub trait QueryMerchant: Send + Sync {
     /// and `false` if it already exists.
     async fn insert_nonce(&self, nonce: &Nonce) -> Result<bool>;
 
+    /// Don't use this function! Use the more descriptive
+    /// [`QueryMerchantExt::insert_revocation_lock()`] and
+    /// [`QueryMerchantExt::insert_revocation_pair()`] functions instead!
+    ///
     /// Insert a revocation lock and optional secret, returning all revocations
     /// that existed prior.
     async fn insert_revocation(
@@ -734,7 +738,6 @@ mod tests {
     }
 
     #[tokio::test]
-    // TODO: modify test to use the two trait functions
     async fn test_insert_revocation() -> Result<()> {
         let conn = create_migrated_db().await?;
         let mut rng = rand::thread_rng();

--- a/src/database/merchant.rs
+++ b/src/database/merchant.rs
@@ -217,7 +217,7 @@ impl QueryMerchant for SqlitePool {
         revocation: &RevocationLock,
     ) -> Result<Vec<Option<RevocationSecret>>> {
         // Call insert_revocation with None
-        insert_revocation(&self, &revocation, None).await
+        insert_revocation(self, revocation, None).await
     }
 
     async fn insert_revocation_pair(
@@ -226,7 +226,7 @@ impl QueryMerchant for SqlitePool {
     ) -> Result<Vec<Option<RevocationSecret>>> {
         // Call insert_revocation with Some secret pulled out of the pair
         insert_revocation(
-            &self,
+            self,
             &revocation_pair.revocation_lock(),
             Some(&revocation_pair.revocation_secret()),
         )

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -379,8 +379,7 @@ pub mod pay {
     };
 
     pub type CustomerRevokePreviousPayToken = Session! {
-        send RevocationLock;
-        send RevocationSecret;
+        send RevocationPair;
         send RevocationLockBlindingFactor;
         // Merchant verifies that the revocation information is valid
         OfferAbort<MerchantIssueNewPayToken, Error>;


### PR DESCRIPTION
This PR implements the downstream changes necessary to incorporate verified revocation pairs into zkabacus (https://github.com/boltlabs-inc/libzkchannels-crypto/pull/178).

There are now two types of database insertions in the `pub trait QueryMerchant` for revocation info, namely `insert_revocation_lock` and `insert_revocation_pair`; these are built using the existing logic in `insert_revocation`, which has been moved out of the pub trait. @yaymukund is that the best way to handle this change?

Additionally, the customer now sends a verified revocation pair to the merchant, instead of a lock and a secret. 

Aside: I'm not familiar with `async/await`, so I'm not sure I handled those parts properly.