### PR TITLE
add self-delay feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ path = "src/bin/merchant/main.rs"
 
 [features]
 allow_explicit_certificate_trust = []
+allow_custom_self_delay = []
+
 
 [dependencies]
 zkabacus-crypto = { git = "https://github.com/boltlabs-inc/libzkchannels-crypto.git", features = ["sqlite"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,11 @@ use {
 pub mod customer;
 pub mod merchant;
 
+#[cfg(all(not(debug_assertions), feature = "allow_custom_self_delay"))]
+compile_error!(
+    "crate cannot be built for release with the `allow_custom_self_delay` feature enabled"
+);
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DatabaseLocation {
@@ -26,17 +31,34 @@ impl DatabaseLocation {
     }
 }
 
-pub fn deserialize_self_delay<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u64, D::Error> {
-    let num = u64::deserialize(deserializer)?;
+pub fn deserialize_self_delay<'de, D: Deserializer<'de>>(
+    _deserializer: D,
+) -> Result<u64, D::Error> {
+    #[cfg(feature = "allow_custom_self_delay")]
+    {
+        let num = u64::deserialize(_deserializer)?;
+        if num < 10 {
+            return Err(de::Error::invalid_value(
+                de::Unexpected::Unsigned(num as u64),
+                &"at least 10",
+            ));
+        }
 
-    if num < 10 {
-        return Err(de::Error::invalid_value(
-            de::Unexpected::Unsigned(num as u64),
-            &"at least 10",
-        ));
+        if num < 120 {
+            eprintln!("Warning: `self_delay` should not be less than 120 outside of");
+            eprintln!("testing. If this is an error, please update the customer");
+            eprintln!("configuration.");
+        }
+        Ok(num)
     }
-
-    Ok(num)
+    #[cfg(not(feature = "allow_custom_self_delay"))]
+    {
+        eprintln!(
+            "Ignoring explicitly specified self-delay value because \
+            this binary was built to only use the default value (24 hours)"
+        );
+        Ok(crate::defaults::shared::self_delay())
+    }
 }
 
 pub fn deserialize_confirmation_depth<'de, D: Deserializer<'de>>(

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,14 +43,9 @@ pub fn deserialize_self_delay<'de, D: Deserializer<'de>>(
                 &"at least 10",
             ));
         }
-
-        if num < 120 {
-            eprintln!("Warning: `self_delay` should not be less than 120 outside of");
-            eprintln!("testing. If this is an error, please update the customer");
-            eprintln!("configuration.");
-        }
         Ok(num)
     }
+
     #[cfg(not(feature = "allow_custom_self_delay"))]
     {
         eprintln!(

--- a/src/config/customer.rs
+++ b/src/config/customer.rs
@@ -68,12 +68,6 @@ impl Config {
             .parent()
             .expect("Merchant configuration path must exist in some parent directory");
 
-        if config.self_delay < 120 {
-            eprintln!("Warning: `self_delay` should not be less than 120 outside of");
-            eprintln!("testing. If this is an error, please update the customer");
-            eprintln!("configuration.");
-        }
-
         // Adjust contained paths to be relative to the config path
         config.database = config
             .database

--- a/src/config/merchant.rs
+++ b/src/config/merchant.rs
@@ -70,12 +70,6 @@ impl Config {
             .parent()
             .expect("Merchant configuration path must exist in some parent directory");
 
-        if config.self_delay < 120 {
-            eprintln!("Warning: `self_delay` should not be less than 120 outside of");
-            eprintln!("testing. If this is an error, please update the merchant");
-            eprintln!("configuration.");
-        }
-
         // Adjust contained paths to be relative to the config path
         config.database = config.database.relative_to(config_dir);
         config.tezos_account.set_relative_path(config_dir);


### PR DESCRIPTION
As described. Closes #266 

I tested this in the following combinations
- building with release and the feature causes a compile error
- running in debug without the feature prints a warning and uses the default value
- running in debug with the feature doesn't print any warnings
- running in debug with the feature and a small value prints the "value-too-small-are-you-sure" warning