### PR TITLE
Fix mutual close

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -222,54 +222,6 @@
       ]
     }
   },
-  "78137f6eabb79ca5fa9c28cbf49d15cebbc9e2626254ef2614d0b4bb410d4ea2": {
-    "query": "\n            SELECT\n                channel_id AS \"channel_id: ChannelId\",\n                status as \"status: ChannelStatus\",\n                contract_id AS \"contract_id: ContractId\",\n                merchant_deposit AS \"merchant_deposit: MerchantBalance\",\n                customer_deposit AS \"customer_deposit: CustomerBalance\",\n                closing_balances AS \"closing_balances: ClosingBalances\"\n            FROM merchant_channels\n            WHERE channel_id LIKE ?\n            LIMIT 2\n            ",
-    "describe": {
-      "columns": [
-        {
-          "name": "channel_id: ChannelId",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "status: ChannelStatus",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "contract_id: ContractId",
-          "ordinal": 2,
-          "type_info": "Blob"
-        },
-        {
-          "name": "merchant_deposit: MerchantBalance",
-          "ordinal": 3,
-          "type_info": "Blob"
-        },
-        {
-          "name": "customer_deposit: CustomerBalance",
-          "ordinal": 4,
-          "type_info": "Blob"
-        },
-        {
-          "name": "closing_balances: ClosingBalances",
-          "ordinal": 5,
-          "type_info": "Blob"
-        }
-      ],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
   "7dda293c8dc3b6752f97f08b0f310f7e289229f1845df7f1452ed376b1e6c759": {
     "query": "\n            SELECT data AS \"data: zkabacus_crypto::customer::Config\"\n            FROM configs\n            INNER JOIN customer_channels ON configs.id = customer_channels.config_id\n            WHERE customer_channels.label = ?\n            LIMIT 1\n            ",
     "describe": {
@@ -580,8 +532,8 @@
       ]
     }
   },
-  "e7093650130533f459a84f8c59498a0b094f8b075898407c5ad79b970a7abca5": {
-    "query": "\n            SELECT\n                channel_id AS \"channel_id: ChannelId\",\n                status as \"status: ChannelStatus\",\n                contract_id AS \"contract_id: ContractId\",\n                merchant_deposit AS \"merchant_deposit: MerchantBalance\",\n                customer_deposit AS \"customer_deposit: CustomerBalance\",\n                closing_balances AS \"closing_balances: ClosingBalances\"\n            FROM merchant_channels\n            ",
+  "e81865613729e1b58aaf3c7eb2af367900ed5f85e5159558dee4fd1a51a0539a": {
+    "query": "\n            SELECT\n                channel_id AS \"channel_id: ChannelId\",\n                status as \"status: ChannelStatus\",\n                contract_id AS \"contract_id: ContractId\",\n                merchant_deposit AS \"merchant_deposit: MerchantBalance\",\n                customer_deposit AS \"customer_deposit: CustomerBalance\",\n                closing_balances AS \"closing_balances: ClosingBalances\",\n                mutual_close_balances AS \"mutual_close_balances: ClosingBalances\"\n            FROM merchant_channels\n            WHERE channel_id LIKE ?\n            LIMIT 2\n            ",
     "describe": {
       "columns": [
         {
@@ -613,6 +565,65 @@
           "name": "closing_balances: ClosingBalances",
           "ordinal": 5,
           "type_info": "Blob"
+        },
+        {
+          "name": "mutual_close_balances: ClosingBalances",
+          "ordinal": 6,
+          "type_info": "Blob"
+        }
+      ],
+      "parameters": {
+        "Right": 1
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true
+      ]
+    }
+  },
+  "f7574a535f3c5e9aacc1f34ccb6a863383bf83e714a863f011c1913c83c3643a": {
+    "query": "\n            SELECT\n                channel_id AS \"channel_id: ChannelId\",\n                status as \"status: ChannelStatus\",\n                contract_id AS \"contract_id: ContractId\",\n                merchant_deposit AS \"merchant_deposit: MerchantBalance\",\n                customer_deposit AS \"customer_deposit: CustomerBalance\",\n                closing_balances AS \"closing_balances: ClosingBalances\",\n                mutual_close_balances AS \"mutual_close_balances: ClosingBalances\"\n            FROM merchant_channels\n            ",
+    "describe": {
+      "columns": [
+        {
+          "name": "channel_id: ChannelId",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "status: ChannelStatus",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "contract_id: ContractId",
+          "ordinal": 2,
+          "type_info": "Blob"
+        },
+        {
+          "name": "merchant_deposit: MerchantBalance",
+          "ordinal": 3,
+          "type_info": "Blob"
+        },
+        {
+          "name": "customer_deposit: CustomerBalance",
+          "ordinal": 4,
+          "type_info": "Blob"
+        },
+        {
+          "name": "closing_balances: ClosingBalances",
+          "ordinal": 5,
+          "type_info": "Blob"
+        },
+        {
+          "name": "mutual_close_balances: ClosingBalances",
+          "ordinal": 6,
+          "type_info": "Blob"
         }
       ],
       "parameters": {
@@ -624,7 +635,8 @@
         false,
         false,
         false,
-        false
+        false,
+        true
       ]
     }
   },

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -38,6 +38,16 @@
       "nullable": []
     }
   },
+  "369ab7505c238e78d2e6c44cbda53355e8f751275a738fcf15f645f3cbae43f7": {
+    "query": "UPDATE merchant_channels\n             SET mutual_close_balances = ?\n             WHERE channel_id = ?",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 2
+      },
+      "nullable": []
+    }
+  },
   "46ea459c9d2e371ace67299de61c55d6e17a6c8b3a8d10e6bfd0771ffc907b0e": {
     "query": "\n            SELECT secret AS \"secret: RevocationSecret\"\n            FROM revocations\n            WHERE lock = ?\n            ",
     "describe": {
@@ -508,6 +518,78 @@
       ]
     }
   },
+  "d3d67ac30fb4289cc50c23f82d662df2f0a13603a59c4fb2ef478963601cc314": {
+    "query": "\n            SELECT\n                mutual_close_balances AS \"mutual_close_balances: MutualCloseBalances\"\n            FROM merchant_channels\n            WHERE channel_id = ?\n            ",
+    "describe": {
+      "columns": [
+        {
+          "name": "mutual_close_balances: MutualCloseBalances",
+          "ordinal": 0,
+          "type_info": "Blob"
+        }
+      ],
+      "parameters": {
+        "Right": 1
+      },
+      "nullable": [
+        true
+      ]
+    }
+  },
+  "d74b5e711d312afed219c829be2f3002fd1a7ed9e9cfe2b9ab0483c5746ccf9d": {
+    "query": "\n            SELECT\n                channel_id AS \"channel_id: ChannelId\",\n                status as \"status: ChannelStatus\",\n                contract_id AS \"contract_id: ContractId\",\n                merchant_deposit AS \"merchant_deposit: MerchantBalance\",\n                customer_deposit AS \"customer_deposit: CustomerBalance\",\n                closing_balances AS \"closing_balances: ClosingBalances\",\n                mutual_close_balances AS \"mutual_close_balances: MutualCloseBalances\"\n            FROM merchant_channels\n            WHERE channel_id LIKE ?\n            LIMIT 2\n            ",
+    "describe": {
+      "columns": [
+        {
+          "name": "channel_id: ChannelId",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "status: ChannelStatus",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "contract_id: ContractId",
+          "ordinal": 2,
+          "type_info": "Blob"
+        },
+        {
+          "name": "merchant_deposit: MerchantBalance",
+          "ordinal": 3,
+          "type_info": "Blob"
+        },
+        {
+          "name": "customer_deposit: CustomerBalance",
+          "ordinal": 4,
+          "type_info": "Blob"
+        },
+        {
+          "name": "closing_balances: ClosingBalances",
+          "ordinal": 5,
+          "type_info": "Blob"
+        },
+        {
+          "name": "mutual_close_balances: MutualCloseBalances",
+          "ordinal": 6,
+          "type_info": "Blob"
+        }
+      ],
+      "parameters": {
+        "Right": 1
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true
+      ]
+    }
+  },
   "d899fc4f2db3fd9360822e5f2c70610aa7961c8926b507824351d16a0cec3d34": {
     "query": "\n            SELECT \n                merchant_deposit as \"merchant_balance: MerchantBalance\",\n                customer_deposit as \"customer_balance: CustomerBalance\"\n            FROM merchant_channels\n            WHERE channel_id = ?\n            LIMIT 2\n            ",
     "describe": {
@@ -532,8 +614,8 @@
       ]
     }
   },
-  "e81865613729e1b58aaf3c7eb2af367900ed5f85e5159558dee4fd1a51a0539a": {
-    "query": "\n            SELECT\n                channel_id AS \"channel_id: ChannelId\",\n                status as \"status: ChannelStatus\",\n                contract_id AS \"contract_id: ContractId\",\n                merchant_deposit AS \"merchant_deposit: MerchantBalance\",\n                customer_deposit AS \"customer_deposit: CustomerBalance\",\n                closing_balances AS \"closing_balances: ClosingBalances\",\n                mutual_close_balances AS \"mutual_close_balances: ClosingBalances\"\n            FROM merchant_channels\n            WHERE channel_id LIKE ?\n            LIMIT 2\n            ",
+  "f4e7912daa7a08c17c12664f55ee7aeea394ab76bb40858446a98221d3a592ac": {
+    "query": "\n            SELECT\n                channel_id AS \"channel_id: ChannelId\",\n                status as \"status: ChannelStatus\",\n                contract_id AS \"contract_id: ContractId\",\n                merchant_deposit AS \"merchant_deposit: MerchantBalance\",\n                customer_deposit AS \"customer_deposit: CustomerBalance\",\n                closing_balances AS \"closing_balances: ClosingBalances\",\n                mutual_close_balances AS \"mutual_close_balances: MutualCloseBalances\"\n            FROM merchant_channels\n            ",
     "describe": {
       "columns": [
         {
@@ -567,61 +649,7 @@
           "type_info": "Blob"
         },
         {
-          "name": "mutual_close_balances: ClosingBalances",
-          "ordinal": 6,
-          "type_info": "Blob"
-        }
-      ],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true
-      ]
-    }
-  },
-  "f7574a535f3c5e9aacc1f34ccb6a863383bf83e714a863f011c1913c83c3643a": {
-    "query": "\n            SELECT\n                channel_id AS \"channel_id: ChannelId\",\n                status as \"status: ChannelStatus\",\n                contract_id AS \"contract_id: ContractId\",\n                merchant_deposit AS \"merchant_deposit: MerchantBalance\",\n                customer_deposit AS \"customer_deposit: CustomerBalance\",\n                closing_balances AS \"closing_balances: ClosingBalances\",\n                mutual_close_balances AS \"mutual_close_balances: ClosingBalances\"\n            FROM merchant_channels\n            ",
-    "describe": {
-      "columns": [
-        {
-          "name": "channel_id: ChannelId",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "status: ChannelStatus",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "contract_id: ContractId",
-          "ordinal": 2,
-          "type_info": "Blob"
-        },
-        {
-          "name": "merchant_deposit: MerchantBalance",
-          "ordinal": 3,
-          "type_info": "Blob"
-        },
-        {
-          "name": "customer_deposit: CustomerBalance",
-          "ordinal": 4,
-          "type_info": "Blob"
-        },
-        {
-          "name": "closing_balances: ClosingBalances",
-          "ordinal": 5,
-          "type_info": "Blob"
-        },
-        {
-          "name": "mutual_close_balances: ClosingBalances",
+          "name": "mutual_close_balances: MutualCloseBalances",
           "ordinal": 6,
           "type_info": "Blob"
         }

--- a/src/bin/merchant/close.rs
+++ b/src/bin/merchant/close.rs
@@ -73,26 +73,7 @@ impl Close {
         .await
         .context("Mutual close timed out while waiting for signature verification")??;
 
-        // Wait for the contract to be closed on chain
-        tezos_client
-            .verify_contract_closed(&contract_id)
-            .await
-            .context(format!(
-                "Failed to confirm that the contract closed in mutual close protocol (id: {})",
-                contract_id
-            ))?;
-
-        // Update the database to indicate a successful mutual close
-        finalize_mutual_close(
-            database.as_ref(),
-            close_state.channel_id(),
-            close_state.customer_balance(),
-            close_state.merchant_balance(),
-        )
-        .await
-        .context(
-            "Failed to finalize mutual close - perhaps the contract was closed by a different flow",
-        )
+        Ok(())
     }
 }
 
@@ -274,8 +255,6 @@ async fn finalize_dispute(
 pub async fn finalize_mutual_close(
     database: &dyn QueryMerchant,
     channel_id: &ChannelId,
-    customer_balance: CustomerBalance,
-    merchant_balance: MerchantBalance,
 ) -> Result<(), anyhow::Error> {
     // Update database to indicate the channel closed successfully.
     database
@@ -290,7 +269,10 @@ pub async fn finalize_mutual_close(
             &channel_id
         ))?;
 
-    // Update database to final channel balances as indicated by the mutualClose entrypoint call.
+    // Retrieve saved mutual close balances
+    let (merchant_balance, customer_balance) = todo!()
+     
+    // Update final channel balances to mutual close values 
     database
         .update_closing_balances(
             channel_id,

--- a/src/bin/merchant/main.rs
+++ b/src/bin/merchant/main.rs
@@ -277,6 +277,20 @@ async fn dispatch_channel(
         .await?;
     }
 
+    if contract_state.status()? == ContractStatus::Closed
+        && channel.status == ChannelStatus::PendingMutualClose
+    {
+        // Update the database to indicate a successful mutual close
+        close::finalize_mutual_close(
+            database,
+            &channel.channel_id,
+        )
+        .await
+        .context(
+            "Failed to finalize mutual close - perhaps the contract was closed by a different flow",
+        )?;
+    }
+
     Ok(())
 }
 

--- a/src/bin/merchant/main.rs
+++ b/src/bin/merchant/main.rs
@@ -277,6 +277,10 @@ async fn dispatch_channel(
         .await?;
     }
 
+    // The channel has not reacted to a customer posting a mutual close transaction on chain
+    // The condition is
+    // - the contract is closed, but
+    // - the channel status is `PendingMutualClose`
     if contract_state.status()? == ContractStatus::Closed
         && channel.status == ChannelStatus::PendingMutualClose
     {

--- a/src/database/migrations/merchant/202106211725_setup.sql
+++ b/src/database/migrations/merchant/202106211725_setup.sql
@@ -37,7 +37,8 @@ CREATE TABLE merchant_channels (
       "dispute",
       "closed"
     )),
-  closing_balances BLOB NOT NULL
+  closing_balances BLOB NOT NULL,
+  mutual_close_balances BLOB
 );
 
 CREATE INDEX merchant_channels_channel_id ON merchant_channels (channel_id);

--- a/src/escrow/tezos.rs
+++ b/src/escrow/tezos.rs
@@ -1411,15 +1411,6 @@ impl TezosClient {
             .map_err(MutualCloseError)
         }
     }
-
-    /// Verify that the specified contract is closed.
-    ///
-    /// This function will wait until the contract status is CLOSED at the expected confirmation
-    /// depth and is called by the merchant.
-    #[allow(unused)]
-    pub async fn verify_contract_closed(&self, contract_id: &ContractId) -> Result<(), Error> {
-        todo!()
-    }
 }
 
 fn is_zero(buf: &[u8]) -> bool {


### PR DESCRIPTION
Closes #337 

Before, the merchant's `close()` function called `finalize_mutual_close`. Now, the merchant's watcher calls it.

The most substantial change here is an addition of `MutualCloseBalances` to the merchant database. The merchant watcher cannot tell from the contract itself what the final mutual close balances are, so we need to persist them via the database instead. These changes include
- updating the database schema to include this optional field (`sqlx-data.json` is the generated file)
- updating the database Rust type to include the field
- adding a getter and setter for the field for a specific channel id

Observation: the getters for each field of the database are a bit clumsy -- they're all identical except for the item being queried. Would it be better to have a single getter for the whole row, and have the caller pull out the field relevant to them?

Testing: I think this scenario is not currently caught by the e2e testing infrastructure. Should determine whether it is and either fix it in this PR or make a new issue + PR to address it.