### PR TITLE
Fix expiry status flow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,9 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install dependencies
-        run: sudo apt install libudev-dev
+        run: |
+          sudo apt-get update
+          sudo apt install libudev-dev
 
       - name: Format check
         run: cargo fmt -- --check

--- a/dev/test-zeekoe.py
+++ b/dev/test-zeekoe.py
@@ -70,6 +70,9 @@ def info(msg):
 def log(msg, debug=True):
     if debug: print("%s%s%s" % (BBlack, msg, NC))
 
+def err(msg):
+    print("%sERROR?%s %s%s%s" % (BBlack, NC, RED, msg, NC))
+
 def fatal_error(msg):
     print("%sERROR:%s %s%s%s" % (BBlack, NC, RED, msg, NC))
     sys.exit(-1)
@@ -127,16 +130,17 @@ def run_command(cmd, verbose):
     while True:
         try:
             output = process.stdout.readline()
-            if process.poll() is not None:
-                break
             if output:
                 output_text = output.strip().decode('utf-8')
                 log("-> %s" % output_text, verbose)
+            error = process.stderr.readline()
+            if error:
+                err("-> %s" % error.strip().decode('utf-8'))
+            if process.poll() is not None:
+                break
         except KeyboardInterrupt:
             process.terminate()
     rc = process.poll()
-    error = process.stderr.readline()
-    log("-> %s" % error.strip().decode('utf-8'), verbose)
     return output_text, rc
 
 def zkchannel_merchant(*args, config, verbose, **kwargs):


### PR DESCRIPTION
Closes #298 

Three main changes in this PR:
- Fixes status flow. @indomitableSwan , can you confirm that there is no scenario where a unilateral customer close would be permissible, but a unilateral merchant close would not be (and vice versa)?
- Updates `with_closeable_channel` function to account for the change. This was hardcoded to only transition into `PendingClose`, but it actually should also permit `PendingExpiry`.
- Updates logging in the test infra. This is not perfect, but it was previously only logging things from `stderr` at termination, which missed a lot of important inline / non-fatal errors. It now logs all of those, and also everything else (including non-error info) that zeekoe logs using stderr. This over-information problem would be solved by #91 (or another more nuanced logging approach).

