### PR TITLE
Add pay tests

### DIFF
--- a/integration_tests/common.rs
+++ b/integration_tests/common.rs
@@ -7,15 +7,13 @@ use std::{
     sync::Mutex,
 };
 
-use {
-    futures::future::{self, Join},
-    structopt::StructOpt,
-    strum::IntoEnumIterator,
-    strum_macros::EnumIter,
-    tokio::{task::JoinHandle, time::Duration},
-    tracing::info_span,
-    tracing_futures::Instrument,
-};
+use futures::future::{self, Join};
+use structopt::StructOpt;
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
+use tokio::{task::JoinHandle, time::Duration};
+use tracing::info_span;
+use tracing_futures::Instrument;
 
 use crate::{await_log, TestLogs};
 

--- a/integration_tests/common.rs
+++ b/integration_tests/common.rs
@@ -7,14 +7,15 @@ use std::{
     sync::Mutex,
 };
 
-use futures::future::{self, Join};
-use rand::prelude::StdRng;
-use structopt::StructOpt;
-use strum::IntoEnumIterator;
-use strum_macros::EnumIter;
-use tokio::{task::JoinHandle, time::Duration};
-use tracing::info_span;
-use tracing_futures::Instrument;
+use {
+    futures::future::{self, Join},
+    structopt::StructOpt,
+    strum::IntoEnumIterator,
+    strum_macros::EnumIter,
+    tokio::{task::JoinHandle, time::Duration},
+    tracing::info_span,
+    tracing_futures::Instrument,
+};
 
 use crate::{await_log, TestLogs};
 
@@ -105,7 +106,7 @@ macro_rules! merchant_cli {
 }
 pub(crate) use merchant_cli;
 
-pub async fn setup(rng: &StdRng, tezos_uri: String) -> ServerFuture {
+pub async fn setup(tezos_uri: String) -> ServerFuture {
     let _ = fs::create_dir("integration_tests/gen");
 
     // Create self-signed SSL certificate in the generated directory
@@ -136,7 +137,7 @@ pub async fn setup(rng: &StdRng, tezos_uri: String) -> ServerFuture {
     let watch = customer_cli!(Watch, vec!["watch"]);
     let customer_handle = tokio::spawn(
         watch
-            .run(rng.clone(), customer_config)
+            .run(customer_config)
             .instrument(info_span!(Party::CustomerWatcher.to_str())),
     );
 

--- a/integration_tests/main.rs
+++ b/integration_tests/main.rs
@@ -1,6 +1,5 @@
 pub(crate) mod common;
 
-use dialectic::unary::S;
 use zeekoe::{
     amount::Amount,
     customer::{self, database::StateName as CustomerStatus, zkchannels::Command},
@@ -10,20 +9,18 @@ use zeekoe::{
 };
 use zkabacus_crypto::{CustomerBalance, MerchantBalance};
 
-use {
-    anyhow::Context,
-    common::{customer_cli, merchant_cli, Party},
-    std::{
-        convert::TryInto,
-        fs::{File, OpenOptions},
-        io::Read,
-        panic,
-        str::FromStr,
-        time::Duration,
-    },
-    structopt::StructOpt,
-    thiserror::Error,
+use anyhow::Context;
+use common::{customer_cli, merchant_cli, Party};
+use std::{
+    convert::TryInto,
+    fs::{File, OpenOptions},
+    io::Read,
+    panic,
+    str::FromStr,
+    time::Duration,
 };
+use structopt::StructOpt;
+use thiserror::Error;
 
 #[tokio::main]
 pub async fn main() {
@@ -362,20 +359,22 @@ impl Test {
                     merchant_balance: expected_merchant_balance,
                 }) => {
                     // Parse current channel details for customer
-                    let customer_detail_json = customer_cli!(Show, vec!["show", &self.name, "--json"])
-                        .run(customer_config.clone())
-                        .await
-                        .context("Failed to show customer channel")?;
+                    let customer_detail_json =
+                        customer_cli!(Show, vec!["show", &self.name, "--json"])
+                            .run(customer_config.clone())
+                            .await
+                            .context("Failed to show customer channel")?;
 
                     let customer_channel: customer::zkchannels::PublicChannelDetails =
                         serde_json::from_str(&customer_detail_json)?;
 
                     // Parse current channel details for merchant
                     let channel_id = &customer_channel.channel_id().to_string();
-                    let merchant_details_json = merchant_cli!(Show, vec!["show", channel_id, "--json"])
-                        .run(merchant_config.clone())
-                        .await
-                        .context("Failed to show merchant channel")?;
+                    let merchant_details_json =
+                        merchant_cli!(Show, vec!["show", channel_id, "--json"])
+                            .run(merchant_config.clone())
+                            .await
+                            .context("Failed to show merchant channel")?;
 
                     let merchant_channel: merchant::zkchannels::PublicChannelDetails =
                         serde_json::from_str(&merchant_details_json)?;

--- a/src/bin/customer.rs
+++ b/src/bin/customer.rs
@@ -1,4 +1,7 @@
-use {anyhow::Context, futures::FutureExt, std::convert::identity, structopt::StructOpt};
+use anyhow::Context;
+use futures::FutureExt;
+use std::convert::identity;
+use structopt::StructOpt;
 
 use zeekoe::customer::{
     cli::{self, Customer::*},

--- a/src/bin/customer.rs
+++ b/src/bin/customer.rs
@@ -1,8 +1,4 @@
-use anyhow::Context;
-use futures::FutureExt;
-use rand::{rngs::StdRng, SeedableRng};
-use std::convert::identity;
-use structopt::StructOpt;
+use {anyhow::Context, futures::FutureExt, std::convert::identity, structopt::StructOpt};
 
 use zeekoe::customer::{
     cli::{self, Customer::*},
@@ -22,28 +18,25 @@ pub async fn main_with_cli(cli: Cli) -> Result<(), anyhow::Error> {
         })
     });
 
-    // TODO: let this be made deterministic during testing
-    let rng = StdRng::from_entropy();
-
     match cli.customer {
         Configure(cli::Configure { .. }) => {
             drop(config);
             tokio::task::spawn_blocking(|| Ok(edit::edit_file(config_path)?)).await?
         }
         List(list) => {
-            println!("{}", list.run(rng, config.await?).await?);
+            println!("{}", list.run(config.await?).await?);
             Ok(())
         }
         Show(show) => {
-            println!("{}", show.run(rng, config.await?).await?);
+            println!("{}", show.run(config.await?).await?);
             Ok(())
         }
-        Rename(rename) => rename.run(rng, config.await?).await,
-        Establish(establish) => establish.run(rng, config.await?).await,
-        Pay(pay) => pay.run(rng, config.await?).await,
-        Refund(refund) => refund.run(rng, config.await?).await,
-        Close(close) => close.run(rng, config.await?).await,
-        Watch(watch) => watch.run(rng, config.await?).await,
+        Rename(rename) => rename.run(config.await?).await,
+        Establish(establish) => establish.run(config.await?).await,
+        Pay(pay) => pay.run(config.await?).await,
+        Refund(refund) => refund.run(config.await?).await,
+        Close(close) => close.run(config.await?).await,
+        Watch(watch) => watch.run(config.await?).await,
     }
 }
 

--- a/src/canonicalize_json_micheline/src/lib.rs
+++ b/src/canonicalize_json_micheline/src/lib.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
-use std::string::FromUtf8Error;
+use std::{collections::HashMap, string::FromUtf8Error};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct PrimitiveApplication {

--- a/src/zkchannels.rs
+++ b/src/zkchannels.rs
@@ -1,3 +1,15 @@
 //! The complete zkchannels protocol implementation
 pub mod customer;
 pub mod merchant;
+
+use rand::{rngs::StdRng, SeedableRng};
+
+/// Get a pseudorandom number generator. This should only be used in two circumstances:
+/// (1) you need an RNG and you don't have one
+/// (2) in order to use your RNG, you'd have to clone it (e.g. spawning a new thread with
+/// an `async move` block)
+///
+/// Don't clone RNGs!
+pub fn zkchannels_rng() -> StdRng {
+    StdRng::from_entropy()
+}

--- a/src/zkchannels/customer.rs
+++ b/src/zkchannels/customer.rs
@@ -4,12 +4,13 @@
 use tracing::warn;
 use webpki::DnsNameRef;
 
-use anyhow::Context;
-use async_trait::async_trait;
-use rand::rngs::StdRng;
-use sqlx::SqlitePool;
-use std::{sync::Arc, time::Duration};
-use thiserror::Error;
+use {
+    anyhow::Context,
+    async_trait::async_trait,
+    sqlx::SqlitePool,
+    std::{sync::Arc, time::Duration},
+    thiserror::Error,
+};
 
 use crate::{
     customer::{
@@ -42,7 +43,7 @@ pub trait Command {
 
     /// Run the command to completion using the given random number generator for all randomness and
     /// the given customer configuration.
-    async fn run(self, rng: StdRng, config: Config) -> Result<Self::Output, anyhow::Error>;
+    async fn run(self, config: Config) -> Result<Self::Output, anyhow::Error>;
 }
 
 /// Connect to a given [`ZkChannelAddress`], configured using the parameters in the [`Config`].

--- a/src/zkchannels/customer.rs
+++ b/src/zkchannels/customer.rs
@@ -4,13 +4,11 @@
 use tracing::warn;
 use webpki::DnsNameRef;
 
-use {
-    anyhow::Context,
-    async_trait::async_trait,
-    sqlx::SqlitePool,
-    std::{sync::Arc, time::Duration},
-    thiserror::Error,
-};
+use anyhow::Context;
+use async_trait::async_trait;
+use sqlx::SqlitePool;
+use std::{sync::Arc, time::Duration};
+use thiserror::Error;
 
 use crate::{
     customer::{

--- a/src/zkchannels/customer/close.rs
+++ b/src/zkchannels/customer/close.rs
@@ -5,10 +5,12 @@
 //* This architecture is flexible; we could alternately allow the customer CLI to wait (hang) until
 //* it receives confirmation (e.g. call `process_mutual_close_confirmation` directly from
 //* `mutual_close()`).
-use async_trait::async_trait;
-use rand::rngs::StdRng;
-use serde::Serialize;
-use std::{convert::Infallible, fs::File, path::PathBuf};
+use {
+    async_trait::async_trait,
+    rand::rngs::StdRng,
+    serde::Serialize,
+    std::{convert::Infallible, fs::File, path::PathBuf},
+};
 
 use crate::{
     abort,
@@ -21,6 +23,7 @@ use crate::{
     protocol::{close, Party::Customer},
     timeout::WithTimeout,
     transport::ZkChannelAddress,
+    zkchannels::zkchannels_rng,
 };
 use zkabacus_crypto::{
     customer::ClosingMessage, ChannelId, CloseState, CloseStateSignature, CustomerBalance,
@@ -34,11 +37,8 @@ use anyhow::Context;
 impl Command for Close {
     type Output = ();
 
-    async fn run(
-        self,
-        mut rng: StdRng,
-        config: self::Config,
-    ) -> Result<Self::Output, anyhow::Error> {
+    async fn run(self, config: self::Config) -> Result<Self::Output, anyhow::Error> {
+        let mut rng = zkchannels_rng();
         let database = database(&config)
             .await
             .context("Failed to connect to local database")?;
@@ -55,7 +55,7 @@ impl Command for Close {
             .await
             .context("Unilateral close failed")?;
         } else {
-            mutual_close(&self, rng, config)
+            mutual_close(&self, &mut rng, config)
                 .await
                 .context("Mutual close failed")?;
         }
@@ -397,7 +397,7 @@ pub async fn finalize_expiry(
 
 async fn mutual_close(
     close: &Close,
-    rng: StdRng,
+    rng: &mut StdRng,
     config: self::Config,
 ) -> Result<(), anyhow::Error> {
     let database = database(&config)
@@ -515,7 +515,7 @@ async fn finalize_mutual_close(
 }
 
 async fn zkabacus_close(
-    mut rng: StdRng,
+    mut rng: &mut StdRng,
     database: &dyn QueryCustomer,
     channel_name: &ChannelName,
     config: &self::Config,

--- a/src/zkchannels/customer/close.rs
+++ b/src/zkchannels/customer/close.rs
@@ -5,12 +5,10 @@
 //* This architecture is flexible; we could alternately allow the customer CLI to wait (hang) until
 //* it receives confirmation (e.g. call `process_mutual_close_confirmation` directly from
 //* `mutual_close()`).
-use {
-    async_trait::async_trait,
-    rand::rngs::StdRng,
-    serde::Serialize,
-    std::{convert::Infallible, fs::File, path::PathBuf},
-};
+use async_trait::async_trait;
+use rand::rngs::StdRng;
+use serde::Serialize;
+use std::{convert::Infallible, fs::File, path::PathBuf};
 
 use crate::{
     abort,

--- a/src/zkchannels/customer/establish.rs
+++ b/src/zkchannels/customer/establish.rs
@@ -1,10 +1,8 @@
-use {
-    anyhow::Context,
-    async_trait::async_trait,
-    rand::rngs::StdRng,
-    serde::Serialize,
-    std::{convert::TryInto, fs::File, path::PathBuf},
-};
+use anyhow::Context;
+use async_trait::async_trait;
+use rand::rngs::StdRng;
+use serde::Serialize;
+use std::{convert::TryInto, fs::File, path::PathBuf};
 
 use std::convert::Infallible;
 

--- a/src/zkchannels/customer/establish.rs
+++ b/src/zkchannels/customer/establish.rs
@@ -1,8 +1,10 @@
-use anyhow::Context;
-use async_trait::async_trait;
-use rand::rngs::StdRng;
-use serde::Serialize;
-use std::{convert::TryInto, fs::File, path::PathBuf};
+use {
+    anyhow::Context,
+    async_trait::async_trait,
+    rand::rngs::StdRng,
+    serde::Serialize,
+    std::{convert::TryInto, fs::File, path::PathBuf},
+};
 
 use std::convert::Infallible;
 
@@ -27,6 +29,7 @@ use crate::{
     protocol::{establish, Party::Customer},
     timeout::WithTimeout,
     transport::ZkChannelAddress,
+    zkchannels::zkchannels_rng,
 };
 
 use tezedge::crypto::Prefix;
@@ -47,11 +50,7 @@ struct Establishment {
 impl Command for Establish {
     type Output = ();
 
-    async fn run(
-        self,
-        mut rng: StdRng,
-        config: self::Config,
-    ) -> Result<Self::Output, anyhow::Error> {
+    async fn run(self, config: self::Config) -> Result<Self::Output, anyhow::Error> {
         let Self {
             label,
             merchant: address,
@@ -61,6 +60,7 @@ impl Command for Establish {
             off_chain,
             ..
         } = self;
+        let mut rng = zkchannels_rng();
 
         // Connect to the customer database
         let database = database(&config)

--- a/src/zkchannels/customer/manage.rs
+++ b/src/zkchannels/customer/manage.rs
@@ -1,11 +1,9 @@
-use {
-    anyhow::Context,
-    async_trait::async_trait,
-    comfy_table::{Cell, Table},
-    serde::{Deserialize, Serialize},
-    serde_with::{serde_as, DisplayFromStr},
-    zkabacus_crypto::{ChannelId, CustomerBalance, MerchantBalance},
-};
+use anyhow::Context;
+use async_trait::async_trait;
+use comfy_table::{Cell, Table};
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
+use zkabacus_crypto::{ChannelId, CustomerBalance, MerchantBalance};
 
 use crate::{
     amount::Amount,

--- a/src/zkchannels/customer/manage.rs
+++ b/src/zkchannels/customer/manage.rs
@@ -1,10 +1,11 @@
-use anyhow::Context;
-use async_trait::async_trait;
-use comfy_table::{Cell, Table};
-use rand::rngs::StdRng;
-use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DisplayFromStr};
-use zkabacus_crypto::{ChannelId, CustomerBalance, MerchantBalance};
+use {
+    anyhow::Context,
+    async_trait::async_trait,
+    comfy_table::{Cell, Table},
+    serde::{Deserialize, Serialize},
+    serde_with::{serde_as, DisplayFromStr},
+    zkabacus_crypto::{ChannelId, CustomerBalance, MerchantBalance},
+};
 
 use crate::{
     amount::Amount,
@@ -76,7 +77,7 @@ impl PublicChannelDetails {
 #[async_trait]
 impl Command for Show {
     type Output = String;
-    async fn run(self, _rng: StdRng, config: self::Config) -> Result<Self::Output, anyhow::Error> {
+    async fn run(self, config: self::Config) -> Result<Self::Output, anyhow::Error> {
         let database = database(&config)
             .await
             .context("Failed to connect to local database")?;
@@ -96,7 +97,7 @@ impl Command for Show {
 impl Command for List {
     type Output = String;
 
-    async fn run(self, _rng: StdRng, config: self::Config) -> Result<Self::Output, anyhow::Error> {
+    async fn run(self, config: self::Config) -> Result<Self::Output, anyhow::Error> {
         let database = database(&config)
             .await
             .context("Failed to connect to local database")?;
@@ -144,7 +145,7 @@ impl Command for List {
 impl Command for Rename {
     type Output = ();
 
-    async fn run(self, _rng: StdRng, config: self::Config) -> Result<Self::Output, anyhow::Error> {
+    async fn run(self, config: self::Config) -> Result<Self::Output, anyhow::Error> {
         database(&config)
             .await
             .context("Failed to connect to local database")?

--- a/src/zkchannels/customer/pay.rs
+++ b/src/zkchannels/customer/pay.rs
@@ -20,6 +20,7 @@ use crate::{
     offer_abort, proceed,
     protocol::{pay, Party::Customer},
     timeout::WithTimeout,
+    zkchannels::zkchannels_rng,
 };
 
 use super::{connect, database, Command};
@@ -28,11 +29,8 @@ use super::{connect, database, Command};
 impl Command for Pay {
     type Output = ();
 
-    async fn run(
-        self,
-        mut rng: StdRng,
-        config: self::Config,
-    ) -> Result<Self::Output, anyhow::Error> {
+    async fn run(self, config: self::Config) -> Result<Self::Output, anyhow::Error> {
+        let mut rng = zkchannels_rng();
         let payment_amount = self.pay.try_into()?;
 
         let database = database(&config)
@@ -285,8 +283,8 @@ async fn zkabacus_unlock(
 impl Command for Refund {
     type Output = ();
 
-    async fn run(self, rng: StdRng, config: Config) -> Result<Self::Output, anyhow::Error> {
+    async fn run(self, config: Config) -> Result<Self::Output, anyhow::Error> {
         // A refund is merely a negative payment
-        self.into_negative_pay().run(rng, config).await
+        self.into_negative_pay().run(config).await
     }
 }

--- a/src/zkchannels/customer/watch.rs
+++ b/src/zkchannels/customer/watch.rs
@@ -17,6 +17,7 @@ use crate::{
         Config,
     },
     escrow::types::ContractStatus,
+    zkchannels::zkchannels_rng,
     TestLogs,
 };
 
@@ -28,7 +29,7 @@ const MAX_INTERVAL_SECONDS: u64 = 60;
 impl Command for Watch {
     type Output = ();
 
-    async fn run(self, rng: StdRng, config: Config) -> Result<Self::Output, anyhow::Error> {
+    async fn run(self, config: Config) -> Result<Self::Output, anyhow::Error> {
         let database = database(&config)
             .await
             .context("Customer chain-watching daemon failed to connect to local database")?;
@@ -96,7 +97,7 @@ impl Command for Watch {
                 for channel in channels {
                     let database = database.clone();
                     let config = config.clone();
-                    let mut rng = rng.clone();
+                    let mut rng = zkchannels_rng();
                     let off_chain = self.off_chain;
                     tokio::spawn(async move {
                         match dispatch_channel(


### PR DESCRIPTION
Addresses #350 and #351 

Main changes:
- changing of command enum in integration test to accept a balance/payment amount
- removing RNG from CLI `run()` function parameters
- 4 new integration tests related to payment
- moving channel-related outcomes to a new struct (to handle the event of testing a non-existent channel on purpose)

Also would appreciate a check that I didn't lose anything in the rebase!
