### PR TITLE
Fix syntax error in e2e yaml bash

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Get branch name
         id: branch
         run: |
-          if "${{github.event_name}}" == "schedule"
+          if [[ "${{github.event_name}}" == "schedule" ]]
           then
             echo "::set-output name=branch::main"
           else


### PR DESCRIPTION
There was an error in the bash script that picks the branch name in the e2e yaml file. The error didn't get picked up until the weekly tests were run again.

Note: is there a way to force run the schedule version of a Github action instead of waiting for the weekly tests to catch errors?